### PR TITLE
fix actual guarantees provided by the current Raft integration

### DIFF
--- a/qdrant/v0.8.x/distributed_deployment.md
+++ b/qdrant/v0.8.x/distributed_deployment.md
@@ -110,8 +110,8 @@ Operation with points, on the other hand, are not going through the consensus in
 Qdrant is not intended to have strong transaction guarantees, which allows it to perform point operations with low overhead.
 In practice, it means that Qdrant does not guarantee atomic distributed updates but allows you to wait until the [operation is complete](../points/#awaiting-result) to see the results of your writes.
 
-Collection operations, on the contrary, are part of the consensus.
-It means that all nodes should agree on what operations should be applied before the service will perform them.
+Collection operations, on the contrary, are part of the consensus which guarantees that all operations are durable and eventually executed by all nodes.
+In practice it means that a majority of node agree on what operations should be applied before the service will perform them.
 
 Practically, it means that if the cluster is in a transition state - either electing a new leader after a failure or starting up, the collection update operations will be denied.
 


### PR DESCRIPTION
This PR makes the documentation clearer regarding the guarantees provided by our Raft integration.