### PR TITLE
Replace `with_vector` with `with_vectors`

### DIFF
--- a/qdrant/v1.0.x/points.md
+++ b/qdrant/v1.0.x/points.md
@@ -458,7 +458,7 @@ client.retrieve(
 )
 ```
 
-This method has additional parameters `with_vector` and `with_payload`. 
+This method has additional parameters `with_vectors` and `with_payload`. 
 Using these parameters, you can select parts of the point you want as a result.
 Excluding helps you not to waste traffic transmitting useless data.
 
@@ -499,7 +499,7 @@ POST /collections/{collection_name}/points/scroll
     },
     "limit": 1,
     "with_payload": true,
-    "with_vector": false
+    "with_vectors": false
 }
 ```
 
@@ -516,7 +516,7 @@ client.scroll(
     ),
     limit=1,
     with_payload=True,
-    with_vector=False,
+    with_vectors=False,
 )
 ```
 

--- a/qdrant/v1.0.x/search.md
+++ b/qdrant/v1.0.x/search.md
@@ -575,7 +575,7 @@ client = QdrantClient("localhost", port=6333)
 client.search(
     collection_name="{collection_name}",
     query_vector=[0.2, 0.1, 0.9, 0.7],
-    with_vector=True,
+    with_vectors=True,
     with_payload=True,
     limit=10,
     offset=100


### PR DESCRIPTION
This PR uses the plural form for all the occurrences of the `with_vector` parameter. It makes the docs consistent with the current naming.