### PR TITLE
fix: rewrite instructions

### DIFF
--- a/cloud/v0.1.x/cloud-quick-start.md
+++ b/cloud/v0.1.x/cloud-quick-start.md
@@ -3,44 +3,71 @@ title: Quick Start in Cloud
 weight: 10
 ---
 
-## Create cluster
+To use Qdrant Cloud, you will need to create at least one cluster. There are two ways to start:
+1. Create a Free Tier cluster with 1 node and a default configuration (1GB RAM, 0.5 CPU and 20GB Disk).
+2. Configure a custom cluster with additional nodes and more resources. **You will have to provide billing information.**
 
-To start working with the Qdrant cloud platform, you have to create at least one cluster. You can do so on the clusters overview section by clicking the “Create” button.
-You will need to choose the initial configuration for your cluster as the next step. 
+We recommend that you use the Free Tier cluster for testing purposes. The capacity should be enough to serve up to 1M vectors of 768dim. To calculate your needs, refer to [capacity planning](https://qdrant.tech/documentation/cloud/capacity/). 
 
+## Create a Free Tier cluster
 
-* Define the name of your cluster. 
-* Choose the cloud platform provider. During the beta phase, only the AWS platform will be available for cluster deployment. GCP and Azure cloud providers will be added soon. If you have special requirements, [let us know](mailto:cloud@qdrant.io).
-* Choose the data center region. During the beta phase, only the us-east data center location will be choosable in the selection. Other cloud regions can be activated on demand. [Let us know](mailto:cloud@qdrant.io) if you have latency concerns or other topology-related requirements.
-* Choose the memory size for a node. 2GB to 64GB options are available. Please refer to the [Capacity and Sizing](https://qdrant.tech/documentation/cloud/capacity/) section to make the right choice here. If you need an even higher capacity per node, [let us know](mailto:cloud@qdrant.io), we can provide machines of any size.
-* Choose the number CPU’s per node. 0.5 to 16 CPU options are available, whereas the maximal and minimal number of CPU’s is coupled to the chosen memory size. 
-* And finally, choose the number of nodes you want the cluster to be deployed on. Each node is automatically attached with a disc space offering enough space for your data if you decide to put the metadata or even the index on the disc storage.
-* Your cluster will be reachable on port 443 and 6333 (Rest endpoint) and 6334 (Grpc)
+1. Start in the **Overview** section of the Dashboard. 
+2. Under **Set a Cluster Up** enter a **Cluster name**.
+3. Click **Create Free Tier** and then **Continue**.
+4. Under **Get an API Key**, select the cluster and click **Get API Key**.
+5. Save the API key, as you won't be able to request it again. Click **Continue**. 
 
+Now you can test cluster access. Your generated request should be similar to this one:
 
-### Free tier
+```bash
+curl \
+  -X GET https://xyz-example.eu-central.aws.staging-cloud.qdrant.io:6333 \
+  --header 'api-key: <provide-your-own-key>'
+```
+6. Open Terminal and run the request. You should get a response that looks like this:
 
-Every account is eligible for one free tier cluster.
-Just choose the name, use the default configuration with 1GB memory and 0.5 CPU, and you are good to go.
-You can use this cluster for testing purposes. The capacity should be enough to serve up to 1M vectors of 768dim, but [it depends…](https://qdrant.tech/documentation/cloud/capacity/). 
+```bash
+{"title":"qdrant - vector search engine","version":"1.1.0"}
+```
+> **Note:** The API key needs to be present in the request header every time you make a request via Rest or gRPC interface.
 
-## Authentication
+## Create a custom cluster
 
-Have you created your first Qdrant cloud cluster?
-Alright, now you want to access it from within your application.
-Jump to the “Access” section, there, you will see a list of all available API keys.
-Create a new one for your newly created cluster by choosing the name from the cluster name from the select menu.
+> **Prerequisite:** Please make sure you have provided billing information before creating a custom cluster. 
 
-You can also create a key that provides access to several clusters.
-The secret key is only shown once after creation and if you lose it, you will need to create a new one. We recommend rotating the keys from time to time anyway.
+1. Start in the **Overview** section of the Dashboard. 
+2. Under **Set a Cluster Up** scroll down and click **Create Custom Tier**.
+3. A window will open. Enter a cluster **Name**.
+4. In the Beta version, you can only deploy to AWS. We are currentl;y developing support GCP and Azure. 
+5. Choose from one of five data center regions. If you have latency concerns or other topology-related requirements, [let us know](mailto:cloud@qdrant.io).
+6. Configure RAM size for each node (2GB to 64GB). 
+> Please read [Capacity and Sizing](https://qdrant.tech/documentation/cloud/capacity/) to make the right choice. If you need more capacity per node, [let us know](mailto:cloud@qdrant.io).
+7. Choose the number of CPUs per node (0.5 core to 16 cores). The max/min number of CPUs is coupled to the chosen RAM size. 
+8. Select the number of nodes you want the cluster to be deployed on. 
+> Each node is automatically attached with a disc space offering enough space for your data if you decide to put the metadata or even the index on the disc storage.
+9. Click **Create** and wait for your cluster to be provisioned.
 
-The API key needs to be present in the request header each time you make a request to the Qdrant cloud cluster via Rest or gRPC interface.
-All official Qdrant clients for Python, Go, and Rust are supporting the API key parameter. 
+Your cluster will be reachable on port 443 and 6333 (Rest endpoint) and 6334 (Grpc).
 
-<!---
-Examples with clients
--->
+10. Follow **Step 6** from the above **Create a Free Tier cluster** instruction set to verify cluster access
 
+## Creating additional API keys
+
+The API key is only shown once after creation. If you lose it, you will need to create a new one. 
+However, we recommend rotating the keys from time to time.
+
+1. To create more API keys, go to the **Access** section in the Dashboard.
+2. The **Access Management** list will display all available API keys.
+3. Click **Create** and choose a cluster name from the dropdown menu.
+> **Note:** You can create a key that provides access to multiple clusters. Simply check off which cluster in the dropdown
+4. Click **OK** and retrieve your API key. 
+
+## Authentication via Python client
+
+Now that you have created your first cluster and key, you might want to access Qdrant Cloud from within your application.
+Our official Qdrant clients for Python, Go, and Rust all support the API key parameter. 
+
+Sample Python code
 
 ```python
 from qdrant_client import QdrantClient
@@ -52,8 +79,3 @@ qdrant_client = QdrantClient(
 )
 ```
 
-```bash
-curl \
-  -X GET https://xyz-example.eu-central.aws.staging-cloud.qdrant.io:6333 \
-  --header 'api-key: <provide-your-own-key>'
-```


### PR DESCRIPTION
1. I used the GUI and wrote the steps exactly as executed.
2. Giving a Python/Curl example together is not appropriate as this is a Quick Start document. 
3. We should look into removing the Python example and putting it into a separate document.
4. Advise to have screenshots if possible. This is an industry standard for Quick Start type docs.
5. Clear delineation between free tier and custom cluster.