### PR TITLE
Update integrations.md to fix index error

### DIFF
--- a/qdrant/v1.1.x/integrations.md
+++ b/qdrant/v1.1.x/integrations.md
@@ -102,7 +102,7 @@ qdrant_client.upsert(
     collection_name="MyCollection",
     points=Batch(
         ids=[1],
-        vectors=[response["data"]["embedding"]],
+        vectors=[response["data"][0]["embedding"]],
     )
 )
 ```


### PR DESCRIPTION
fix array slice index error

Without the [0] we get the following error
`TypeError: list indices must be integers or slices, not str`

This is because the structure of the openai json object is

```
{
   "data":[
      {
         "embedding":[
            0.2122c....
         ],
         "index":0,
         "object":"embedding"
      }
   ]
}
```