### PR TITLE
Describe per vector HNSW and quantization parameters

### DIFF
--- a/qdrant/v1.1.x/collections.md
+++ b/qdrant/v1.1.x/collections.md
@@ -141,13 +141,15 @@ client.recreate_collection(
 )
 ```
 
+For rare use cases, it is possible to create a collection without any vector storage.
+
+*Available since v1.1.1*
+
 For each named vector you can optionally specify
 [`hnsw_config`](../indexing/#vector-index) or
 [`quantization_config`](../quantization/#setting-up-quantization-in-qdrant) to
 deviate from the collection configuration. This can be useful to fine-tune
 search performance on a vector level.
-
-For rare use cases, it is possible to create a collection without any vector storage.
 
 ### Delete collection
 

--- a/qdrant/v1.1.x/collections.md
+++ b/qdrant/v1.1.x/collections.md
@@ -141,6 +141,12 @@ client.recreate_collection(
 )
 ```
 
+For each named vector you can optionally specify
+[`hnsw_config`](../indexing/#vector-index) or
+[`quantization_config`](../quantization/#setting-up-quantization-in-qdrant) to
+deviate from the collection configuration. This can be useful to fine-tune
+search performance on a vector level.
+
 For rare use cases, it is possible to create a collection without any vector storage.
 
 ### Delete collection

--- a/qdrant/v1.1.x/indexing.md
+++ b/qdrant/v1.1.x/indexing.md
@@ -121,7 +121,7 @@ The corresponding parameters could be configured in the configuration file:
 
 ```yaml
 storage:
-  # Default parameters of HNSW Index. Could be override for each collection individually
+  # Default parameters of HNSW Index. Could be overridden for each collection or named vector individually
   hnsw_index:
     # Number of edges per node in the index graph.
     # Larger the value - more accurate the search, more space required.
@@ -136,6 +136,10 @@ storage:
     full_scan_threshold: 10000
 
 ```
+
+The HNSW parameters can also be configured on a collection and named vector
+level by setting [`hnsw_config`](../indexing/#vector-index) to fine-tune search
+performance.
 
 And so in the process of creating a [collection](../collections). The `ef` parameter is configured during [the search](../search) and by default is equal to `ef_construct`.
 

--- a/qdrant/v1.1.x/indexing.md
+++ b/qdrant/v1.1.x/indexing.md
@@ -137,15 +137,17 @@ storage:
 
 ```
 
-The HNSW parameters can also be configured on a collection and named vector
-level by setting [`hnsw_config`](../indexing/#vector-index) to fine-tune search
-performance.
-
 And so in the process of creating a [collection](../collections). The `ef` parameter is configured during [the search](../search) and by default is equal to `ef_construct`.
 
 HNSW is chosen for several reasons.
 First, HNSW is well-compatible with the modification that allows Qdrant to use filters during a search.
 Second, it is one of the most accurate and fastest algorithms, according to [public benchmarks](https://github.com/erikbern/ann-benchmarks).
+
+*Available since v1.1.1*
+
+The HNSW parameters can also be configured on a collection and named vector
+level by setting [`hnsw_config`](../indexing/#vector-index) to fine-tune search
+performance.
 
 ## Filtrable Index
 

--- a/qdrant/v1.1.x/quantization.md
+++ b/qdrant/v1.1.x/quantization.md
@@ -51,10 +51,14 @@ Currently, Work-in-progress.
 
 ## Setting up Quantization in Qdrant
 
-You can configure quantization for a collection by specifying the quantization parameters in the `quantization_config` section of the collection configuration. This can also be enabled per vector by specifying `quantization_config` in a named vector.
+You can configure quantization for a collection by specifying the quantization parameters in the `quantization_config` section of the collection configuration.
 
 Quantization will be automatically applied to all vectors during the indexation process.
 Quantized vectors are stored alongside the original vectors in the collection, so you will still have access to the original vectors if you need them.
+
+*Available since v1.1.1*
+
+The `quantization_config` can also be set on a per vector basis by specifying it in a named vector.
 
 ### Setting up Scalar Quantization
 

--- a/qdrant/v1.1.x/quantization.md
+++ b/qdrant/v1.1.x/quantization.md
@@ -51,7 +51,7 @@ Currently, Work-in-progress.
 
 ## Setting up Quantization in Qdrant
 
-You can configure quantization for a collection by specifying the quantization parameters in the `quantization` section of the collection configuration.
+You can configure quantization for a collection by specifying the quantization parameters in the `quantization_config` section of the collection configuration. This can also be enabled per vector by specifying `quantization_config` in a named vector.
 
 Quantization will be automatically applied to all vectors during the indexation process.
 Quantized vectors are stored alongside the original vectors in the collection, so you will still have access to the original vectors if you need them.


### PR DESCRIPTION
This describes the usage of vector specific HNSW and quantization parameters in named vectors.

This feature was introduced in <https://github.com/qdrant/qdrant/pull/1675> and <https://github.com/qdrant/qdrant/pull/1680>.