### PR TITLE
Document metrics endpoint

### DIFF
--- a/qdrant/v1.1.x/telemetry.md
+++ b/qdrant/v1.1.x/telemetry.md
@@ -49,8 +49,7 @@ There are several different techniques that we use to anonymize the data:
 
 You can see exact version of anomymized collected data by accessing the [telemetry API](https://qdrant.github.io/qdrant/redoc/index.html#tag/service/operation/telemetry) with `anonymize=true` parameter.
 
-For example,
-[http://localhost:6333/telemetry?details_level=6&anonymize=true](http://localhost:6333/telemetry?details_level=6&anonymize=true)
+For example, <http://localhost:6333/telemetry?details_level=6&anonymize=true>
 
 
 ## Deactivate telemetry
@@ -67,7 +66,6 @@ If you decide to deactivate telemetry, we kindly ask you to share your feedback 
 
 ## Request information deletion
 
-
 We provide an email address so that users can request the complete removal of their data from all of our tools.
 
 To do so, send an email to privacy@qdrant.com containing the unique identifier generated for your Qdrant installation.
@@ -75,3 +73,14 @@ You can find this identifier in the telemetry API response (`"id"` field), or in
 
 Any questions regarding the management of the data we collect can also be sent to this email address.
 
+## Metrics
+
+To incorporate Qdrant into your own monitoring system you can use the metrics
+endpoint. It reports metrics data similar to telemetry, but in Prometheus
+format.
+
+Metrics endpoint: <http://localhost:6333/metrics>
+
+Integrating with Prometheus and Grafana is easy. Simply
+[configure](https://prometheus.io/docs/prometheus/latest/getting_started/#configure-prometheus-to-monitor-the-sample-targets)
+your Qdrant host as scrape target.


### PR DESCRIPTION
This documents the `/metrics` endpoint.

Because I didn't want to create a whole new page for this, I've added it to the telemetry section. The reported metrics data is very similar to it thus I thought it would be fitting.