### PR TITLE
1.2.x: update for `indexing_threshold` and `memmap_threshold` `=0` to disable

### DIFF
--- a/qdrant/v1.1.x/collections.md
+++ b/qdrant/v1.1.x/collections.md
@@ -187,12 +187,12 @@ client.update_collection(
 )
 ```
 
-This command enables indexing for segments that have more than 10000 KB of vectors stored.
+This command enables indexing for segments that have more than 10000 kB of vectors stored.
 
 ## Collection info
 
 Qdrant allows determining the configuration parameters of an existing collection to better understand how the points are
-distributed and indexed. 
+distributed and indexed.
 
 ```http
 GET /collections/{collection_name}

--- a/qdrant/v1.2.x/collections.md
+++ b/qdrant/v1.2.x/collections.md
@@ -165,7 +165,7 @@ client.delete_collection(collection_name="{collection_name}")
 ### Update collection parameters
 
 Dynamic parameter updates may be helpful, for example, for more efficient initial loading of vectors.
-With these settings, you can disable indexing during the upload process.  And enable it immediately after the upload is finished.
+For example, you can disable indexing during the upload process, and enable it immediately after the upload is finished.
 As a result, you will not waste extra computation resources on rebuilding the index.
 
 ```http
@@ -187,7 +187,7 @@ client.update_collection(
 )
 ```
 
-This command enables indexing for segments that have more than 10000 KB of vectors stored.
+This command enables indexing for segments that have more than 10000 kB of vectors stored.
 
 ## Collection info
 
@@ -262,7 +262,7 @@ There are, however, some other attributes you might be interested in:
 
 In some cases, you might be surprised the value of `indexed_vectors_count` is lower than `vectors_count`. This is an intended behaviour and
 depends on the [optimizer configuration](../optimizer). A new index segment is built if the size of non-indexed vectors is higher than the
-value of `indexing_threshold`(in KB).  If your collection is very small or the dimensionality of the vectors is low, there might be no HNSW segment
+value of `indexing_threshold`(in kB).  If your collection is very small or the dimensionality of the vectors is low, there might be no HNSW segment
 created and `indexed_vectors_count` might be equal to `0`.
 
 It is possible to reduce the `indexing_threshold` for an existing collection by [updating collection parameters](#update-collection-parameters).

--- a/qdrant/v1.2.x/configuration.md
+++ b/qdrant/v1.2.x/configuration.md
@@ -86,19 +86,17 @@ storage:
     # If not set, will be automatically selected considering the number of available CPUs.
     max_segment_size_kb: null
 
-    # Maximum size (in KiloBytes) of vectors to store in-memory per segment.
+    # Maximum size (in kilobytes) of vectors to store in-memory per segment.
     # Segments larger than this threshold will be stored as read-only memmaped file.
-    # To enable memmap storage, lower the threshold
-    # Note: 1Kb = 1 vector of size 256
+    # Memmap storage is disabled by default, to enable it, set this threshold to a reasonable value.
     # To explicitly disable mmap optimization, set to `0`.
-    # If not set, will be disabled by default.
+    # Note: 1Kb = 1 vector of size 256
     memmap_threshold_kb: null
 
-    # Maximum size (in KiloBytes) of vectors allowed for plain index.
-    # Default value based on https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md
-    # Note: 1Kb = 1 vector of size 256
+    # Maximum size (in kilobytes) of vectors allowed for plain index, exceeding this threshold will enable vector indexing
+    # Default value is 20,000, based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.
     # To explicitly disable vector indexing, set to `0`.
-    # If not set, the default value will be used.
+    # Note: 1kB = 1 vector of size 256.
     indexing_threshold_kb: 20000
 
     # Interval between forced flushes.
@@ -230,7 +228,7 @@ tls:
 The configuration is validated on startup. If a configuration is loaded but
 validation fails, a warning is logged. E.g.:
 
-```
+```text
 WARN Settings configuration file has validation errors:
 WARN - storage.optimizers.memmap_threshold: value 123 invalid, must be 1000 or larger
 WARN - storage.hnsw_index.m: value 1 invalid, must be from 4 to 10000

--- a/qdrant/v1.2.x/how_to.md
+++ b/qdrant/v1.2.x/how_to.md
@@ -133,7 +133,7 @@ client.recreate_collection(
 
 In this scenario you can increase the precision of the search by increasing the `ef` and `m` parameters of the HNSW index, even with limited RAM.
 
-```
+```json
 ...
 "hnsw_config": {
     "m": 64,
@@ -478,7 +478,7 @@ If you are not using Rust, you might want to consider parallelizing your upload 
 In case you are doing an initial upload of a large dataset, you might want to disable indexing during upload.
 It will enable to avoid unnecessary indexing of vectors, which will be overwritten by the next batch.
 
-To disable indexing during upload, set `indexing_threshold` to some large value, like `1000000000`:
+To disable indexing during upload, set `indexing_threshold` to `0`:
 
 ```http
 PUT /collections/{collection_name}
@@ -489,7 +489,7 @@ PUT /collections/{collection_name}
       "distance": "Cosine"
     },
     "optimizers_config": {
-        "indexing_threshold": 1000000000
+        "indexing_threshold": 0
     }
 }
 ```
@@ -503,12 +503,12 @@ client.recreate_collection(
     collection_name="{collection_name}",
     vectors_config=models.VectorParams(size=768, distance=models.Distance.COSINE),
     optimizers_config=models.OptimizersConfigDiff(
-        indexing_threshold=1000000000,
+        indexing_threshold=0,
     ),
 )
 ```
 
-After upload is done, you can enable indexing by setting `indexing_threshold` to default value(20000):
+After upload is done, you can enable indexing by setting `indexing_threshold` to a desired value (default is 20000):
 
 ```http
 PATCH /collections/{collection_name}
@@ -592,16 +592,17 @@ default_segment_number: 0
 # If not set, will be automatically selected considering the number of available CPUs.
 max_segment_size_kb: null
 
-# Maximum size (in KiloBytes) of vectors to store in-memory per segment.
+# Maximum size (in kilobytes) of vectors to store in-memory per segment.
 # Segments larger than this threshold will be stored as read-only memmaped file.
-# To enable memmap storage, lower the threshold
+# Memmap storage is disabled by default, to enable it, set this threshold to a reasonable value.
+# To disable memmap storage, set this to `0`.
 # Note: 1Kb = 1 vector of size 256
-# If not set, mmap will not be used.
 memmap_threshold_kb: null
 
-# Maximum size (in KiloBytes) of vectors allowed for plain index.
-# Default value based on https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md
-# Note: 1Kb = 1 vector of size 256
+# Maximum size (in kilobytes) of vectors allowed for plain index, exceeding this threshold will enable vector indexing
+# Default value is 20,000, based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.
+# To disable vector indexing, set to `0`.
+# Note: 1kB = 1 vector of size 256.
 indexing_threshold_kb: 20000
 ```
 
@@ -612,7 +613,7 @@ The values of those parameters will affect how Qdrant handles updates of the dat
 
 - If you have enough RAM and CPU, it is fine to go with default values - Qdrant will index all vectors as fast as possible.
 - If you have a limited amount of RAM, you can set `memmap_threshold_kb=20000` to the same value as `indexing_threshold_kb`. This ensures that all vectors will be stored on disk during the optimization iteration running the indexation.
-- If you are doing bulk updates, you can set `indexing_threshold_kb=100000000` (some very large value) to **disable** indexing during bulk updates. It will speed up the process significantly, but will require additional parameter change after bulk updates are finished.
+- If you are doing bulk updates, you can set `indexing_threshold_kb=0` (or some very large value) to **disable** indexing during bulk updates. It will speed up the process significantly, but will require re-setting the parameter after bulk updates are finished.
 
 Depending on your collection, you might not have enough vectors per segment to start building the index.
 E.g. if you have 100k vecotrs and 8 segments, one for each CPU core, each segment will have only 12.5k vectors, which is not enough to build index.

--- a/qdrant/v1.2.x/optimizer.md
+++ b/qdrant/v1.2.x/optimizer.md
@@ -73,15 +73,17 @@ Here is an example of parameter values:
 ```yaml
 storage:
   optimizers:
-    # Maximum size (in KiloBytes) of vectors to store in-memory per segment.
+    # Maximum size (in kilobytes) of vectors to store in-memory per segment.
     # Segments larger than this threshold will be stored as read-only memmaped file.
-    # To enable memmap storage, lower the threshold
+    # Memmap storage is disabled by default, to enable it, set this threshold to a reasonable value.
+    # To disable memmap storage, set this to `0`.
     # Note: 1Kb = 1 vector of size 256
     memmap_threshold_kb: 200000
 
-    # Maximum size (in KiloBytes) of vectors allowed for plain index.
-    # Default value based on https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md
-    # Note: 1Kb = 1 vector of size 256
+    # Maximum size (in kilobytes) of vectors allowed for plain index, exceeding this threshold will enable vector indexing
+    # Default value is 20,000, based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.
+    # To disable vector indexing, set to `0`.
+    # Note: 1kB = 1 vector of size 256.
     indexing_threshold_kb: 20000
 ```
 


### PR DESCRIPTION
I missed to update documentation after qdrant/qdrant#1702 was merged. Here is the PR reflected on the docs