### PR TITLE
Move recent v1.1.x changes to v1.2.x

### DIFF
--- a/qdrant/v1.2.x/how_to.md
+++ b/qdrant/v1.2.x/how_to.md
@@ -625,3 +625,29 @@ In this case, you can set `indexing_threshold_kb=5000` to start building index e
 
 
 <!--- ## Move data between clusters -->
+
+## Solve some common errors
+
+### Too many files open (OS error 24)
+
+Each collection segment needs some files to be open. At some point you may encounter the following errors in your server log:
+
+```
+Error: Too many files open (OS error 24)
+```
+
+In such a case you may need to increase the limit of the open files. It might be done, for example, while you launch the Docker container:
+
+```bash
+docker run -d -dlimit nofile=10000:10000 qdrant/qdrant:latest
+```
+
+The command above will set both soft and hard limits to `10000`.
+
+If you are not using Docker, the following command will change the limit for the current user session:
+
+```bash
+ulimit -n 10000
+```
+
+Please note, the command should be executed before you run Qdrant server.

--- a/qdrant/v1.2.x/points.md
+++ b/qdrant/v1.2.x/points.md
@@ -335,6 +335,48 @@ client.set_payload(
 )
 ```
 
+You don't need to know the ids of the points you want to modify. The alternative
+is to use filters.
+
+```http
+POST /collections/{collection_name}/points/payload
+
+{
+    "payload": {
+        "property1": "string",
+        "property2": "string"
+    },
+    "filter": {
+        "must": [
+            {
+                "key": "color",
+                "match": {
+                    "value": "red"
+                }
+            }
+        ]
+    }
+}
+```
+
+```python
+client.set_payload(
+    collection_name="{collection_name}",
+    payload={
+        "property1": "string",
+        "property2": "string",
+    },
+    points=models.Filter(
+        must=[
+            models.FieldCondition(
+                key="color",
+                match=models.MatchValue(value="red"),
+            ),
+        ],
+    ),
+)
+```
+
 ### Delete payload keys
 
 REST API ([Schema](https://qdrant.github.io/qdrant/redoc/index.html#operation/delete_payload)):
@@ -353,6 +395,41 @@ client.delete_payload(
     collection_name="{collection_name}",
     keys=["color", "price"],
     points=[0, 3, 100],
+)
+```
+
+Alternatively, you can use filters to delete payload keys from the points.
+
+```http
+POST /collections/{collection_name}/points/payload/delete
+
+{
+    "keys": ["color", "price"],
+    "filter": {
+        "must": [
+            {
+                "key": "color",
+                "match": {
+                    "value": "red"
+                }
+            }
+        ]
+    }
+}
+```
+
+```python
+client.delete_payload(
+    collection_name="{collection_name}",
+    keys=["color", "price"],
+    points=models.Filter(
+        must=[
+            models.FieldCondition(
+                key="color",
+                match=models.MatchValue(value="red"),
+            ),
+        ],
+    ),
 )
 ```
 
@@ -600,7 +677,7 @@ client.count(
 )
 ```
 
-Returns number of counts mathcing given filtering conditions:
+Returns number of counts matching given filtering conditions:
 
 ```json
 {


### PR DESCRIPTION
There were two PRs to `v1.1.x` since `v1.2.x` was started: #103 and #105 This PR adapts the `v1.2.x` accordingly.