### PR TITLE
Fix the description of the indexing_threshold

### DIFF
--- a/qdrant/v0.10.x/collections.md
+++ b/qdrant/v0.10.x/collections.md
@@ -137,7 +137,7 @@ client.update_collection(
 )
 ```
 
-This command enables indexing for segments that have more than 10000 vectors stored.
+This command enables indexing for segments that have more than 10000 KBs.
 
 ## Collection aliases
 

--- a/qdrant/v0.11.x/collections.md
+++ b/qdrant/v0.11.x/collections.md
@@ -139,7 +139,7 @@ client.update_collection(
 )
 ```
 
-This command enables indexing for segments that have more than 10000 vectors stored.
+This command enables indexing for segments that have more than 10000 KBs.
 
 ## Collection info
 

--- a/qdrant/v0.3.x/collections.md
+++ b/qdrant/v0.3.x/collections.md
@@ -91,7 +91,7 @@ POST /collections
 }
 ```
 
-This command enables indexing for segments that have more than 10000 vectors stored.
+This command enables indexing for segments that have more than 10000 KBs.
 
 
 <!-- 

--- a/qdrant/v0.5.x/collections.md
+++ b/qdrant/v0.5.x/collections.md
@@ -82,7 +82,7 @@ PATCH /collections/example_collection
 }
 ```
 
-This command enables indexing for segments that have more than 10000 vectors stored.
+This command enables indexing for segments that have more than 10000 KBs.
 
 
 <!-- 

--- a/qdrant/v0.6.x/collections.md
+++ b/qdrant/v0.6.x/collections.md
@@ -97,7 +97,7 @@ PATCH /collections/example_collection
 }
 ```
 
-This command enables indexing for segments that have more than 10000 vectors stored.
+This command enables indexing for segments that have more than 10000 KBs.
 
 
 <!-- 

--- a/qdrant/v0.7.x/collections.md
+++ b/qdrant/v0.7.x/collections.md
@@ -82,7 +82,7 @@ PATCH /collections/example_collection
 }
 ```
 
-This command enables indexing for segments that have more than 10000 vectors stored.
+This command enables indexing for segments that have more than 10000 KBs.
 
 
 <!-- 

--- a/qdrant/v0.8.x/collections.md
+++ b/qdrant/v0.8.x/collections.md
@@ -91,7 +91,7 @@ PATCH /collections/{collection_name}
 }
 ```
 
-This command enables indexing for segments that have more than 10000 vectors stored.
+This command enables indexing for segments that have more than 10000 KBs.
 
 
 <!-- 

--- a/qdrant/v0.9.x/collections.md
+++ b/qdrant/v0.9.x/collections.md
@@ -91,7 +91,7 @@ PATCH /collections/{collection_name}
 }
 ```
 
-This command enables indexing for segments that have more than 10000 vectors stored.
+This command enables indexing for segments that have more than 10000 KBs.
 
 
 <!-- 

--- a/qdrant/v1.0.x/collections.md
+++ b/qdrant/v1.0.x/collections.md
@@ -179,7 +179,7 @@ client.update_collection(
 )
 ```
 
-This command enables indexing for segments that have more than 10000 vectors stored.
+This command enables indexing for segments that have more than 10000 KBs.
 
 ## Collection info
 

--- a/qdrant/v1.1.x/collections.md
+++ b/qdrant/v1.1.x/collections.md
@@ -187,7 +187,7 @@ client.update_collection(
 )
 ```
 
-This command enables indexing for segments that have more than 10000 vectors stored.
+This command enables indexing for segments that have more than 10000 KBs.
 
 ## Collection info
 


### PR DESCRIPTION
The `indexing_threshold` was described as related to the number of vectors, not the size in KBs. I fixed that up to v1.1.x and will provide another PR for v1.2.x.