### PR TITLE
Fix the description of the indexing_threshold

### DIFF
--- a/qdrant/v1.2.x/collections.md
+++ b/qdrant/v1.2.x/collections.md
@@ -187,7 +187,7 @@ client.update_collection(
 )
 ```
 
-This command enables indexing for segments that have more than 10000 vectors stored.
+This command enables indexing for segments that have more than 10000 KB of vectors stored.
 
 ## Collection info
 


### PR DESCRIPTION
This PR changes the description of the `indexing_threshold` in the docs of the `v1.2.x`, in the same way as we did for the previous versions in #115