### PR TITLE
Document recovery mode

### DIFF
--- a/qdrant/v1.2.x/administration.md
+++ b/qdrant/v1.2.x/administration.md
@@ -36,11 +36,12 @@ You can optionally provide the error message that should be used for error respo
 Recovery mode can help in situations where Qdrant fails to start repeatedly.
 When starting in recovery mode, Qdrant only loads collection metadata to prevent
 going out of memory. This allows you to resolve out of memory situations, for
-example, by removing a collection. After resolving Qdrant can be restarted
+example, by deleting a collection. After resolving Qdrant can be restarted
 normally to continue operation.
 
-In recovery mode, collection operations are limited to removing a collection.
-That is because only collection metadata is loaded during recovery.
+In recovery mode, collection operations are limited to
+[deleting](https://qdrant.tech/documentation/collections/#delete-collection) a
+collection. That is because only collection metadata is loaded during recovery.
 
 To enable recovery mode with the Qdrant Docker image you must set the
 environment variable `QDRANT_ALLOW_RECOVERY_MODE=true`. The container will

--- a/qdrant/v1.2.x/administration.md
+++ b/qdrant/v1.2.x/administration.md
@@ -28,3 +28,25 @@ However deletion operations or updates are not forbidden under the write lock.
 This feature enables administrators to prevent a qdrant process from using more disk space while permitting users to search and delete unnecessary data.
 
 You can optionally provide the error message that should be used for error responses to users.
+
+## Recovery mode
+
+*Available since v1.2.0*
+
+Recovery mode can help in situations where Qdrant fails to start repeatedly.
+When starting in recovery mode, Qdrant only loads collection metadata to prevent
+going out of memory. This allows you to resolve out of memory situations, for
+example, by removing a collection. After resolving Qdrant can be restarted
+normally to continue operation.
+
+In recovery mode, collection operations are limited to removing a collection.
+That is because only collection metadata is loaded during recovery.
+
+To enable recovery mode with the Qdrant Docker image you must set the
+environment variable `QDRANT_ALLOW_RECOVERY_MODE=true`. The container will
+restart in recovery mode if initialisation fails. This behavior is disabled by
+default.
+
+If using a Qdrant binary, recovery mode can be enabled by setting a recovery
+message in an environment variable, such as
+`QDRANT__STORAGE__RECOVERY_MODE="My recovery message"`.

--- a/qdrant/v1.2.x/administration.md
+++ b/qdrant/v1.2.x/administration.md
@@ -44,9 +44,9 @@ In recovery mode, collection operations are limited to
 collection. That is because only collection metadata is loaded during recovery.
 
 To enable recovery mode with the Qdrant Docker image you must set the
-environment variable `QDRANT_ALLOW_RECOVERY_MODE=true`. The container will
-restart in recovery mode if initialisation fails. This behavior is disabled by
-default.
+environment variable `QDRANT_ALLOW_RECOVERY_MODE=true`. The container will try
+to start normally first, and restarts in recovery mode if initialisation fails
+due to an out of memory error. This behavior is disabled by default.
 
 If using a Qdrant binary, recovery mode can be enabled by setting a recovery
 message in an environment variable, such as


### PR DESCRIPTION
This adds documentation for the recovery mode.

This describes:
- what it is
- when it is useful
- how it can be used
- how to enable it