### PR TITLE
Document TLS

### DIFF
--- a/qdrant/v1.2.x/install.md
+++ b/qdrant/v1.2.x/install.md
@@ -93,10 +93,10 @@ Among other things, the configuration file allows you to specify the following s
 
 See the comments in the [configuration file itself](https://github.com/qdrant/qdrant/blob/master/config/config.yaml) for details.
 
-<aside role="status">Qdrant has no authentication by default and new instances
-are open to everyone. See
-[Authentication](https://qdrant.tech/documentation/security/#authentication)
-for details on how to secure your instance.</aside>
+<aside role="status">Qdrant has no encryption or authentication by default and
+new instances are open to everyone. Please read
+[Security](https://qdrant.tech/documentation/security/) carefully for details on
+how to secure your instance.</aside>
 
 ## Python client
 

--- a/qdrant/v1.2.x/quick_start.md
+++ b/qdrant/v1.2.x/quick_start.md
@@ -25,10 +25,9 @@ In this case Qdrant will use default configuration and store all data under `./q
 
 Now Qdrant should be accessible at [localhost:6333](http://localhost:6333)
 
-<aside role="status">Qdrant has no authentication by default and new instances
-are open to everyone. See
-[Authentication](https://qdrant.tech/documentation/security/#authentication)
-for details on how to secure your instance.</aside>
+<aside role="status">Qdrant has no encryption or authentication by default and new instances
+are open to everyone. Please read [Security](https://qdrant.tech/documentation/security/)
+carefully for details on how to secure your instance.</aside>
 
 ### Local mode
 

--- a/qdrant/v1.2.x/security.md
+++ b/qdrant/v1.2.x/security.md
@@ -31,7 +31,7 @@ service:
   api_key: your_secret_api_key_here
 ```
 
-<aside role="alert">TLS must be used to prevent leaking the API key over an unencrypted connection.</aside>
+<aside role="alert"><a href="#tls">TLS</a> must be used to prevent leaking the API key over an unencrypted connection.</aside>
 
 For using API key based authentication in Qdrant cloud see the cloud
 [Authentication](https://qdrant.tech/documentation/cloud/cloud-quick-start/#authentication)
@@ -58,4 +58,79 @@ qdrant_client = QdrantClient(
     port=6333,
     api_key="your_secret_api_key_here",
 )
+```
+
+## TLS
+
+*Available as of v1.2.0*
+
+TLS for encrypted connections can be enabled on your Qdrant instance to secure
+connections.
+
+<aside role="alert">Connections are unencrypted by default. This allows sniffing and [MitM](https://en.wikipedia.org/wiki/Man-in-the-middle_attack) attacks.</aside>
+
+First make sure you have a certificate and private key for TLS, usually in
+`.pem` format. On your local machine you may use
+[mkcert](https://github.com/FiloSottile/mkcert#readme) to generate a self signed
+certificate.
+
+To enable TLS, set the following properties in the Qdrant configuration and
+restart:
+
+```yaml
+service:
+  # Use HTTPS for the REST API
+  enable_tls: true
+
+# TLS configuration.
+# Required if either service.enable_tls or cluster.p2p.enable_tls is true.
+tls:
+  # Server certificate chain file
+  cert: ./tls/cert.pem
+
+  # Server private key file
+  key: ./tls/key.pem
+```
+
+With TLS enabled, you must start using HTTPS connections. For example:
+
+```bash
+curl -X GET https://localhost:6333
+```
+
+```python
+from qdrant_client import QdrantClient
+
+qdrant_client = QdrantClient(
+    url="https://localhost",
+    port=6333,
+)
+```
+
+Certificate rotation is enabled with a default refresh time of one hour. This
+reloads certificate files every hour while Qdrant is running. This way changed
+certificates are picked up when they get updated externally. The refresh time
+can be tuned by changing the `tls.cert_ttl` setting. You can leave this on, even
+if you don't plan to update your certificates.
+
+Optionally, you can enable client certificate validation on the server against a
+local certificate authority. Set the following properties and restart:
+
+```yaml
+service:
+  # Check user HTTPS client certificate against CA file specified in tls config
+  verify_https_client_certificate: false
+
+# TLS configuration.
+# Required if either service.enable_tls or cluster.p2p.enable_tls is true.
+tls:
+  # Certificate authority certificate file.
+  # This certificate will be used to validate the certificates
+  # presented by other nodes during inter-cluster communication.
+  #
+  # If verify_https_client_certificate is true, it will verify
+  # HTTPS client certificate
+  #
+  # Required if cluster.p2p.enable_tls is true.
+  ca_cert: ./tls/cacert.pem
 ```


### PR DESCRIPTION
This adds documentation for using TLS.

This describes:
- what it is
- how to enable it
- how to use it in clients

This also adds (or updates) a red banner to the installation and quick start section noting that instances are not secure by default, linking to this documentation.