### PR TITLE
Document appendable mmap

### DIFF
--- a/qdrant/v1.2.x/collections.md
+++ b/qdrant/v1.2.x/collections.md
@@ -65,7 +65,7 @@ See [schema definitions](https://qdrant.github.io/qdrant/redoc/index.html#operat
 
 The `on_disk` parameter can be set in the vector configuration. If true, all
 vectors will be stored on disk at all times. This will enable the use of
-[appenable mmap's](https://qdrant.tech/documentation/how_to/#appendable-mmap),
+[appendable mmap's](https://qdrant.tech/documentation/how_to/#appendable-mmap),
 which is suitable for ingesting a large amount of data.
 
 ### Create collection from another collection
@@ -162,9 +162,9 @@ search performance on a vector level.
 *Available as of v1.2.0*
 
 On a per-vector basis you can set `on_disk` to true to store all vectors on disk
-at all times. This will enable the use of [appenable
-mmap's](https://qdrant.tech/documentation/how_to/#appendable-mmap), which is
-suitable for ingesting a large amount of data.
+at all times. This will enable the use of
+[appendable mmap's](https://qdrant.tech/documentation/how_to/#appendable-mmap),
+which is suitable for ingesting a large amount of data.
 
 ### Delete collection
 

--- a/qdrant/v1.2.x/collections.md
+++ b/qdrant/v1.2.x/collections.md
@@ -66,7 +66,7 @@ See [schema definitions](https://qdrant.github.io/qdrant/redoc/index.html#operat
 Vectors all live in RAM for very quick access. The `on_disk` parameter can be
 set in the vector configuration. If true, all vectors will live on disk. This
 will enable the use of
-[mmap's](https://qdrant.tech/documentation/storage/#configuring-memmap-storage),
+[memmaps](https://qdrant.tech/documentation/storage/#configuring-memmap-storage),
 which is suitable for ingesting a large amount of data.
 
 ### Create collection from another collection
@@ -165,7 +165,7 @@ search performance on a vector level.
 Vectors all live in RAM for very quick access. On a per-vector basis you can set
 `on_disk` to true to store all vectors on disk at all times. This will enable
 the use of
-[mmap's](https://qdrant.tech/documentation/storage/#configuring-memmap-storage),
+[memmaps](https://qdrant.tech/documentation/storage/#configuring-memmap-storage),
 which is suitable for ingesting a large amount of data.
 
 ### Delete collection

--- a/qdrant/v1.2.x/collections.md
+++ b/qdrant/v1.2.x/collections.md
@@ -65,7 +65,7 @@ See [schema definitions](https://qdrant.github.io/qdrant/redoc/index.html#operat
 
 The `on_disk` parameter can be set in the vector configuration. If true, all
 vectors will be stored on disk at all times. This will enable the use of
-[appendable mmap's](https://qdrant.tech/documentation/how_to/#appendable-mmap),
+[appendable mmap's](https://qdrant.tech/documentation/storage/#configuring-memmap-storage),
 which is suitable for ingesting a large amount of data.
 
 ### Create collection from another collection
@@ -163,7 +163,7 @@ search performance on a vector level.
 
 On a per-vector basis you can set `on_disk` to true to store all vectors on disk
 at all times. This will enable the use of
-[appendable mmap's](https://qdrant.tech/documentation/how_to/#appendable-mmap),
+[appendable mmap's](https://qdrant.tech/documentation/storage/#configuring-memmap-storage),
 which is suitable for ingesting a large amount of data.
 
 ### Delete collection

--- a/qdrant/v1.2.x/collections.md
+++ b/qdrant/v1.2.x/collections.md
@@ -63,9 +63,10 @@ See [schema definitions](https://qdrant.github.io/qdrant/redoc/index.html#operat
 
 *Available as of v1.2.0*
 
-The `on_disk` parameter can be set in the vector configuration. If true, all
-vectors will be stored on disk at all times. This will enable the use of
-[appendable mmap's](https://qdrant.tech/documentation/storage/#configuring-memmap-storage),
+Vectors all live in RAM for very quick access. The `on_disk` parameter can be
+set in the vector configuration. If true, all vectors will live on disk. This
+will enable the use of
+[mmap's](https://qdrant.tech/documentation/storage/#configuring-memmap-storage),
 which is suitable for ingesting a large amount of data.
 
 ### Create collection from another collection
@@ -161,9 +162,10 @@ search performance on a vector level.
 
 *Available as of v1.2.0*
 
-On a per-vector basis you can set `on_disk` to true to store all vectors on disk
-at all times. This will enable the use of
-[appendable mmap's](https://qdrant.tech/documentation/storage/#configuring-memmap-storage),
+Vectors all live in RAM for very quick access. On a per-vector basis you can set
+`on_disk` to true to store all vectors on disk at all times. This will enable
+the use of
+[mmap's](https://qdrant.tech/documentation/storage/#configuring-memmap-storage),
 which is suitable for ingesting a large amount of data.
 
 ### Delete collection

--- a/qdrant/v1.2.x/collections.md
+++ b/qdrant/v1.2.x/collections.md
@@ -59,7 +59,14 @@ In addition to the required options, you can also specify custom values for the 
 
 Default parameters for the optional collection parameters are defined in [configuration file](https://github.com/qdrant/qdrant/blob/master/config/config.yaml).
 
-See [schema definitions](https://qdrant.github.io/qdrant/redoc/index.html#operation/create_collection) and a [configuration file](https://github.com/qdrant/qdrant/blob/master/config/config.yaml) for more information about collection parameters.
+See [schema definitions](https://qdrant.github.io/qdrant/redoc/index.html#operation/create_collection) and a [configuration file](https://github.com/qdrant/qdrant/blob/master/config/config.yaml) for more information about collection and vector parameters.
+
+*Available as of v1.2.0*
+
+The `on_disk` parameter can be set in the vector configuration. If true, all
+vectors will be stored on disk at all times. This will enable the use of
+[appenable mmap's](https://qdrant.tech/documentation/how_to/#appendable-mmap),
+which is suitable for ingesting a large amount of data.
 
 ### Create collection from another collection
 
@@ -151,6 +158,13 @@ For each named vector you can optionally specify
 [`quantization_config`](../quantization/#setting-up-quantization-in-qdrant) to
 deviate from the collection configuration. This can be useful to fine-tune
 search performance on a vector level.
+
+*Available as of v1.2.0*
+
+On a per-vector basis you can set `on_disk` to true to store all vectors on disk
+at all times. This will enable the use of [appenable
+mmap's](https://qdrant.tech/documentation/how_to/#appendable-mmap), which is
+suitable for ingesting a large amount of data.
 
 ### Delete collection
 

--- a/qdrant/v1.2.x/how_to.md
+++ b/qdrant/v1.2.x/how_to.md
@@ -533,6 +533,52 @@ client.update_collection(
 )
 ```
 
+### Appendable mmap
+
+When the vectors you upload do not all fit in memory, you likely want to use
+appendable mmap support. It is suitable for ingesting a large amount of data,
+essential for the billion scale benchmark.
+
+During collection
+[creation](https://qdrant.tech/documentation/collections/#create-collection),
+appendable mmap's may be enabled on a per-vector basis using the `on_disk`
+parameter. This will store vector data on disk at all times, and doesn't depend
+on the `memmap_threshold` to be reached. For example:
+
+```http
+PUT /collections/{collection_name}
+
+{
+    "vectors": {
+        "image": {
+            "size": 400,
+            "distance": "Dot"
+            "on_disk": true,
+        },
+        "text": {
+            "size": 800,
+            "distance": "Cosine"
+            "on_disk": true,
+        }
+    }
+}
+```
+
+```python
+from qdrant_client import QdrantClient
+from qdrant_client.http import models
+
+client = QdrantClient("localhost", port=6333)
+
+client.recreate_collection(
+    collection_name="{collection_name}",
+    vectors_config={
+        "image": models.VectorParams(size=400, distance=models.Distance.DOT, on_disk=True),
+        "text": models.VectorParams(size=800, distance=models.Distance.COSINE, on_disk=True),
+    }
+)
+```
+
 ### Parallel upload into multiple shards
 
 In Qdrant, each collection is split into shards. Each shard has a separate Write-Ahead-Log (WAL), which is responsible for ordering operations.

--- a/qdrant/v1.2.x/how_to.md
+++ b/qdrant/v1.2.x/how_to.md
@@ -533,16 +533,22 @@ client.update_collection(
 )
 ```
 
-### Appendable mmap
+### Upload directly to disk
 
-When the vectors you upload do not all fit in memory, you likely want to use
-appendable mmap support. It is suitable for ingesting a large amount of data,
-essential for the billion scale benchmark.
+When the vectors you upload do not all fit in RAM, you likely want to use
+[memmap](https://qdrant.tech/documentation/storage/#configuring-memmap-storage)
+support.
 
 During collection
 [creation](https://qdrant.tech/documentation/collections/#create-collection),
-appendable mmap's may be enabled on a per-vector basis using the `on_disk`
-parameter. This will store vector data on disk at all times.
+memmaps may be enabled on a per-vector basis using the `on_disk` parameter. This
+will store vector data directly on disk at all times. It is suitable for
+ingesting a large amount of data, essential for the billion scale benchmark.
+
+Using `memmap_threshold_kb` is not recommended in this case. It would require
+the internal optimizer to constantly transform in-memory segments into memmap
+segments on disk. This process is slower, and the optimizer can be a bottleneck
+when ingesting a large amount of data.
 
 Read more about this in
 [Configuring Memmap Storage](https://qdrant.tech/documentation/storage/#configuring-memmap-storage).

--- a/qdrant/v1.2.x/how_to.md
+++ b/qdrant/v1.2.x/how_to.md
@@ -546,9 +546,10 @@ will store vector data directly on disk at all times. It is suitable for
 ingesting a large amount of data, essential for the billion scale benchmark.
 
 Using `memmap_threshold_kb` is not recommended in this case. It would require
-the internal optimizer to constantly transform in-memory segments into memmap
-segments on disk. This process is slower, and the optimizer can be a bottleneck
-when ingesting a large amount of data.
+the [optimizer](https://qdrant.tech/documentation/optimizer/) to constantly
+transform in-memory segments into memmap segments on disk. This process is
+slower, and the optimizer can be a bottleneck when ingesting a large amount of
+data.
 
 Read more about this in
 [Configuring Memmap Storage](https://qdrant.tech/documentation/storage/#configuring-memmap-storage).

--- a/qdrant/v1.2.x/how_to.md
+++ b/qdrant/v1.2.x/how_to.md
@@ -542,42 +542,10 @@ essential for the billion scale benchmark.
 During collection
 [creation](https://qdrant.tech/documentation/collections/#create-collection),
 appendable mmap's may be enabled on a per-vector basis using the `on_disk`
-parameter. This will store vector data on disk at all times, and doesn't depend
-on the `memmap_threshold` to be reached. For example:
+parameter. This will store vector data on disk at all times.
 
-```http
-PUT /collections/{collection_name}
-
-{
-    "vectors": {
-        "image": {
-            "size": 400,
-            "distance": "Dot"
-            "on_disk": true,
-        },
-        "text": {
-            "size": 800,
-            "distance": "Cosine"
-            "on_disk": true,
-        }
-    }
-}
-```
-
-```python
-from qdrant_client import QdrantClient
-from qdrant_client.http import models
-
-client = QdrantClient("localhost", port=6333)
-
-client.recreate_collection(
-    collection_name="{collection_name}",
-    vectors_config={
-        "image": models.VectorParams(size=400, distance=models.Distance.DOT, on_disk=True),
-        "text": models.VectorParams(size=800, distance=models.Distance.COSINE, on_disk=True),
-    }
-)
-```
+Read more about this in
+[Configuring Memmap Storage](https://qdrant.tech/documentation/storage/#configuring-memmap-storage).
 
 ### Parallel upload into multiple shards
 

--- a/qdrant/v1.2.x/optimizer.md
+++ b/qdrant/v1.2.x/optimizer.md
@@ -64,7 +64,7 @@ storage:
 Qdrant allows you to choose the type of indexes and data storage methods used depending on the number of records.
 So, for example, if the number of points is less than 10000, using any index would be less efficient than a brute force scan.
 
-The Indexing Optimizer is used to implement the enabling of indexes and mmap storage when the minimal amount of records is reached.
+The Indexing Optimizer is used to implement the enabling of indexes and memmap storage when the minimal amount of records is reached.
 
 The criteria for starting the optimizer are defined in the configuration file.
 

--- a/qdrant/v1.2.x/quantization.md
+++ b/qdrant/v1.2.x/quantization.md
@@ -278,7 +278,7 @@ There are 3 possible modes to place storage of vectors within the qdrant collect
 
 - **Original on Disk, quantized in RAM** - this is a hybrid mode, allows to obtain a good balance between speed and memory usage. Recommended scenario if you are aiming to shrink the memory footprint while keeping the search speed.
 
-This mode is enabled by setting `always_ram` to `true` in the quantization config while using mmap storage:
+This mode is enabled by setting `always_ram` to `true` in the quantization config while using memmap storage:
 
 ```http
 PUT /collections/{collection_name}
@@ -361,7 +361,7 @@ client.search(
 
 It is recommended to use this mode if you have a large collection and fast storage (e.g. SSD or NVMe).
 
-This mode is enabled by setting `always_ram` to `false` in the quantization config while using mmap storage:
+This mode is enabled by setting `always_ram` to `false` in the quantization config while using memmap storage:
 
 ```http
 PUT /collections/{collection_name}

--- a/qdrant/v1.2.x/storage.md
+++ b/qdrant/v1.2.x/storage.md
@@ -29,7 +29,7 @@ Mmapped files are not directly loaded into RAM. Instead, they use page cache to 
 This scheme allows flexible use of available memory. With sufficient RAM, it is almost as fast as in-memory storage.
 
 <!--
-However, dynamically adding vectors to the mmap file is fairly complicated and is not implemented in Qdrant.
+However, dynamically adding vectors to the memmap file is fairly complicated and is not implemented in Qdrant.
 Thus, segments using mmap storage are `non-appendable` and can only be construed by the optimizer.
 But it only matters for internal operations, so you can safely ignore this fact.
 If you update a vector in a segment with mmap storage, the vector will be moved to appendable segment first, and then the old vector will be deleted from the mmap segment. 
@@ -37,7 +37,7 @@ If you update a vector in a segment with mmap storage, the vector will be moved 
 
 ### Configuring Memmap storage
 
-There are two ways to configure the usage of mmap(also known as on-disk) storage:
+There are two ways to configure the usage of memmap (also known as on-disk) storage:
 
 - Set up `on_disk` option for the vectors in the collection create API:
 
@@ -71,7 +71,7 @@ client.recreate_collection(
 )
 ```
 
-This will create a collection with all vectors immediately stored in mmap storage.
+This will create a collection with all vectors immediately stored in memmap storage.
 This is the recommended way, in case your Qdrant instance operates with fast disks and you are working with large collections.
 
 
@@ -108,12 +108,12 @@ client.recreate_collection(
 )
 ```
 
-The rule of thumb to set the mmap threshold parameter is simple:
+The rule of thumb to set the memmap threshold parameter is simple:
 
-- if you have a balanced use scenario - set mmap threshold the same as `indexing_threshold` (default is 20000). In this case the optimizer will not make any extra runs and will optimize all thresholds at once.
-- if you have a high write load and low RAM - set mmap threshold lower than `indexing_threshold` to e.g. 10000. In this case the optimizer will convert the segments to mmap storage first and will only apply indexing after that.
+- if you have a balanced use scenario - set memmap threshold the same as `indexing_threshold` (default is 20000). In this case the optimizer will not make any extra runs and will optimize all thresholds at once.
+- if you have a high write load and low RAM - set memmap threshold lower than `indexing_threshold` to e.g. 10000. In this case the optimizer will convert the segments to memmap storage first and will only apply indexing after that.
 
-In addition, you can use mmap storage not only for vectors, but also for HNSW index.
+In addition, you can use memmap storage not only for vectors, but also for HNSW index.
 To enable this, you need to set the `hnsw_config.on_disk` parameter to `true` during [creation](../collections/#create-collection) of the collection.
 
 ```http

--- a/qdrant/v1.2.x/storage.md
+++ b/qdrant/v1.2.x/storage.md
@@ -24,16 +24,9 @@ The choice has to be made between the search speed and the size of the RAM used.
 
 **In-memory storage** - Stores all vectors in RAM, has the highest speed since disk access is required only for persistence.
 
-**Memmap storage** -  creates a virtual address space associated with the file on disk. [Wiki](https://en.wikipedia.org/wiki/Memory-mapped_file).
+**Memmap storage** - Creates a virtual address space associated with the file on disk ([wiki](https://en.wikipedia.org/wiki/Memory-mapped_file)).
 Mmapped files are not directly loaded into RAM. Instead, they use page cache to access the contents of the file.
 This scheme allows flexible use of available memory. With sufficient RAM, it is almost as fast as in-memory storage.
-
-<!--
-However, dynamically adding vectors to the memmap file is fairly complicated and is not implemented in Qdrant.
-Thus, segments using mmap storage are `non-appendable` and can only be construed by the optimizer.
-But it only matters for internal operations, so you can safely ignore this fact.
-If you update a vector in a segment with mmap storage, the vector will be moved to appendable segment first, and then the old vector will be deleted from the mmap segment. 
--->
 
 ### Configuring Memmap storage
 

--- a/qdrant/v1.2.x/storage.md
+++ b/qdrant/v1.2.x/storage.md
@@ -15,7 +15,7 @@ A segment can be `appendable` or `non-appendable` depending on the type of stora
 You can freely add, delete and query data in the `appendable` segment.
 With `non-appendable` segment can only read and delete data.
 
-The configuration of the segments in the collection can be different and independent from one another, but at least one `appendable' segment must be present in a collection.
+The configuration of the segments in the collection can be different and independent from one another, but at least one 'appendable' segment must be present in a collection.
 
 ## Vector storage
 


### PR DESCRIPTION
Extends aba5b3ed0bef8febe09715ec72d9d0e51be61758.

Document support for appenadble mmap's. I'm not sure to what detail we want to describe this, but here is my version describing it in a few sentences.

This describes:

- at collection creation, that users can use `on_disk = true` to enable appendable mmap's
- in the how to section, to use appendable mmap's when ingesting a large amount of data