### PR TITLE
Remove link to cloud, we already link to it in authentication

### DIFF
--- a/qdrant/v1.2.x/security.md
+++ b/qdrant/v1.2.x/security.md
@@ -5,10 +5,6 @@ weight: 165
 
 There are various ways to secure your own Qdrant instance.
 
-For authentication on Qdrant cloud refer to its
-[Authentication](https://qdrant.tech/documentation/cloud/cloud-quick-start/#authentication)
-section.
-
 ## Authentication
 
 *Available as of v1.2.0*


### PR DESCRIPTION
This removes a link to cloud Authentication on the security page, because we link to it twice.

We also link to it in the Authentication section.