### PR TITLE
Fix incorrect name of get_aliases function in Python docs

### DIFF
--- a/qdrant/v1.0.x/collections.md
+++ b/qdrant/v1.0.x/collections.md
@@ -377,5 +377,5 @@ from qdrant_client import QdrantClient
 
 client = QdrantClient("localhost", port=6333)
 
-client.list_aliases()
+client.get_aliases()
 ```

--- a/qdrant/v1.1.x/collections.md
+++ b/qdrant/v1.1.x/collections.md
@@ -385,7 +385,7 @@ from qdrant_client import QdrantClient
 
 client = QdrantClient("localhost", port=6333)
 
-client.list_aliases()
+client.get_aliases()
 ```
 
 ### List all collections

--- a/qdrant/v1.2.x/collections.md
+++ b/qdrant/v1.2.x/collections.md
@@ -385,7 +385,7 @@ from qdrant_client import QdrantClient
 
 client = QdrantClient("localhost", port=6333)
 
-client.list_aliases()
+client.get_aliases()
 ```
 
 ### List all collections


### PR DESCRIPTION
Fixes <https://github.com/qdrant/docs/issues/81>.