### PR TITLE
Clarify configuration handling

### DIFF
--- a/qdrant/v1.2.x/configuration.md
+++ b/qdrant/v1.2.x/configuration.md
@@ -59,13 +59,6 @@ If file 5 is provided but not found, an error is shown on startup.
 
 Other supported configuration file formats and extensions include: `.toml`, `.json`, `.ini`.
 
-To see the effective (merged) configuration you can query
-[telemetry](https://qdrant.tech/documentation/telemetry/):
-
-```bash
-curl 'http://localhost:6333/telemetry?details_level=6&anonymize=false'
-```
-
 ## Environment variables
 
 It is possible to set configuration properties using environment variables.


### PR DESCRIPTION
[[Rendered]](https://github.com/qdrant/docs/blob/specify-config-loading/qdrant/v1.2.x/configuration.md)

This clarifies how Qdrant handles multiple configuration files. I figured it'd be good to properly document this after <https://github.com/qdrant/qdrant/pull/1972>.

### Tasks
- [x] Write about configuration ordering/priority
- [x] Don't hint to overwrite `production.yaml` by default
- [x] Describe how to use environment variables for config properties
- [x] Describe how a user might read the effective (merged) configuration