### PR TITLE
Use consistent as of version markers

### DIFF
--- a/qdrant/v0.10.x/collections.md
+++ b/qdrant/v0.10.x/collections.md
@@ -60,7 +60,7 @@ See [schema definitions](https://qdrant.github.io/qdrant/redoc/index.html#operat
 
 ### Collection with multiple vectors
 
-*Available since v0.10.0*
+*Available as of v0.10.0*
 
 It is possible to have multiple vectors per record.
 This feature allows for multiple vector storages per collection. 

--- a/qdrant/v0.10.x/distributed_deployment.md
+++ b/qdrant/v0.10.x/distributed_deployment.md
@@ -3,7 +3,7 @@ title: Distributed deployment
 weight: 50
 ---
 
-Since version v0.8.0 Qdrant supports a distributed deployment mode.
+As of v0.8.0 Qdrant supports a distributed deployment mode.
 In this mode, multiple Qdrant services communicate with each other to distribute the data across the peers to extend the storage capabilities and increase stability.
 
 To enable distributed deployment - enable the cluster mode in the [configuration](../configuration) or using the ENV variable: `QDRANT__CLUSTER__ENABLED=true`.
@@ -161,7 +161,7 @@ For example, if you have 3 nodes, 6 shards could be a good option.
 
 If you want to extend your cluster with new nodes or some nodes become slower than the others, it might be helpful to re-balance the shard distribution in the cluster.
 
-*Since version v0.9.0*, Qdrant allows moving shards between nodes in the cluster and removing nodes from the cluster.
+*As of v0.9.0:* Qdrant allows moving shards between nodes in the cluster and removing nodes from the cluster.
 
 This functionality unlocks the ability to dynamically scale the cluster size without downtime.
 

--- a/qdrant/v0.10.x/filtering.md
+++ b/qdrant/v0.10.x/filtering.md
@@ -330,7 +330,7 @@ You can apply it to [keyword](../payload/#keyword), [integer](../payload/#intege
 
 ### Full Text Match
 
-_Available since version 0.10.0_
+*Available as of v0.10.0*
 
 A special case of the `match` condition is the `text` match condition.
 It allows you to search for a specific substring, token or phrase within the text field.

--- a/qdrant/v0.10.x/indexing.md
+++ b/qdrant/v0.10.x/indexing.md
@@ -54,7 +54,7 @@ You should not create an index for Boolean fields and fields with only a few pos
 
 ### Full-text index
 
-*Available since Qdrant v0.10.0*
+*Available as of v0.10.0*
 
 Qdrant supports full-text search for string payload.
 Full-text index allows you to filter points by the presence of a word or a phrase in the payload field.

--- a/qdrant/v0.10.x/points.md
+++ b/qdrant/v0.10.x/points.md
@@ -250,7 +250,7 @@ In this case, it means that points with the same id will be overwritten when re-
 Idempotence property is useful if you use, for example, a message queue that doesn't provide an exactly-ones guarantee.
 Even with such a system, Qdrant ensures data consistency.
 
-*Available since v0.10.0*
+*Available as of v0.10.0*
 
 If the collection was created with multiple vectors, each vector data should be provided using the vectors name:
 
@@ -555,7 +555,7 @@ Python client:
 
 ## Counting points
 
-*Available since v0.8.4*
+*Available as of v0.8.4*
 
 Sometimes it can be useful to know how many points fit the filter conditions without doing a real search.
 

--- a/qdrant/v0.10.x/search.md
+++ b/qdrant/v0.10.x/search.md
@@ -133,7 +133,7 @@ Example result of this API would be
 
 The `result` contains ordered by `score` list of found point ids.
 
-*Available since v0.10.0*
+*Available as of v0.10.0*
 
 If the collection was created with multiple vectors, the name of the vector to use for searching should be provided:
 
@@ -229,7 +229,7 @@ client.search(
 
 ## Batch search API
 
-*Available since v0.10.0*
+*Available as of v0.10.0*
 
 The batch search API enables to perform multiple search requests via a single request.
 
@@ -413,7 +413,7 @@ Example result of this API would be
 }
 ```
 
-*Available since v0.10.0*
+*Available as of v0.10.0*
 
 If the collection was created with multiple vectors, the name of the vector should be specified in the recommendation request:
 
@@ -442,7 +442,7 @@ Parameter `using` specifies which stored vectors to use for the recommendation.
 
 ## Batch recommendation API
 
-*Available since v0.10.0*
+*Available as of v0.10.0*
 
 Similar to the batch search API in terms of usage and advantages, it enables the batching of recommendation requests.
 
@@ -546,7 +546,7 @@ The result of this API contains one array per recommendation requests.
 
 ## Pagination
 
-*Available since v0.8.3*
+*Available as of v0.8.3*
 
 Search and recommendation APIs allow to skip first results of the search and return only the result starting from some specified offset:
 

--- a/qdrant/v0.10.x/snapshots.md
+++ b/qdrant/v0.10.x/snapshots.md
@@ -3,7 +3,7 @@ title: Snapshots
 weight: 51
 ---
 
-*Available since v0.8.4*
+*Available as of v0.8.4*
 
 Snapshots are performed on a per collection basis and consist in a `tar` archive file containing the necessary data to restore the collection at the time of the snapshot.
 
@@ -85,7 +85,7 @@ If you wish instead to overwrite an existing collection, use the `--force_snapsh
 
 ## Snapshots for the whole storage
 
-*Available since v0.8.5*
+*Available as of v0.8.5*
 
 Sometimes it might be handy to create snapshot not just for a single collection, but for the whole storage, including collection aliases.
 Qdrant provides a dedicated API for that as well. It is similar to collection-level snapshots, but does not require `collecton_name`:

--- a/qdrant/v0.11.x/collections.md
+++ b/qdrant/v0.11.x/collections.md
@@ -62,7 +62,7 @@ See [schema definitions](https://qdrant.github.io/qdrant/redoc/index.html#operat
 
 ### Collection with multiple vectors
 
-*Available since v0.10.0*
+*Available as of v0.10.0*
 
 It is possible to have multiple vectors per record.
 This feature allows for multiple vector storages per collection. 

--- a/qdrant/v0.11.x/distributed_deployment.md
+++ b/qdrant/v0.11.x/distributed_deployment.md
@@ -3,7 +3,7 @@ title: Distributed deployment
 weight: 50
 ---
 
-Since version v0.8.0 Qdrant supports a distributed deployment mode.
+As of v0.8.0 Qdrant supports a distributed deployment mode.
 In this mode, multiple Qdrant services communicate with each other to distribute the data across the peers to extend the storage capabilities and increase stability.
 
 To enable distributed deployment - enable the cluster mode in the [configuration](../configuration) or using the ENV variable: `QDRANT__CLUSTER__ENABLED=true`.
@@ -161,7 +161,7 @@ For example, if you have 3 nodes, 6 shards could be a good option.
 
 If you want to extend your cluster with new nodes or some nodes become slower than the others, it might be helpful to re-balance the shard distribution in the cluster.
 
-*Since version v0.9.0*, Qdrant allows moving shards between nodes in the cluster and removing nodes from the cluster.
+*As of v0.9.0:* Qdrant allows moving shards between nodes in the cluster and removing nodes from the cluster.
 
 This functionality unlocks the ability to dynamically scale the cluster size without downtime.
 
@@ -194,7 +194,7 @@ After that, Qdrant will exclude the node from the consensus, and the instance wi
 
 ## Replication
 
-*Since version v0.11.0*, Qdrant allows to replicate shards between nodes in the cluster.
+*As of v0.11.0:* Qdrant allows to replicate shards between nodes in the cluster.
 
 Shard replication increases the reliability of the cluster by keeping several copies of a shard spread among the cluster.
 This ensure the availability of the shards in case of node failures, except if all replicas are lost.

--- a/qdrant/v0.11.x/filtering.md
+++ b/qdrant/v0.11.x/filtering.md
@@ -332,7 +332,7 @@ You can apply it to [keyword](../payload/#keyword), [integer](../payload/#intege
 
 ### Full Text Match
 
-*Available since version 0.10.0*
+*Available as of v0.10.0*
 
 A special case of the `match` condition is the `text` match condition.
 It allows you to search for a specific substring, token or phrase within the text field.

--- a/qdrant/v0.11.x/indexing.md
+++ b/qdrant/v0.11.x/indexing.md
@@ -54,7 +54,7 @@ You should not create an index for Boolean fields and fields with only a few pos
 
 ### Full-text index
 
-*Available since Qdrant v0.10.0*
+*Available as of v0.10.0*
 
 Qdrant supports full-text search for string payload.
 Full-text index allows you to filter points by the presence of a word or a phrase in the payload field.

--- a/qdrant/v0.11.x/points.md
+++ b/qdrant/v0.11.x/points.md
@@ -250,7 +250,7 @@ In this case, it means that points with the same id will be overwritten when re-
 Idempotence property is useful if you use, for example, a message queue that doesn't provide an exactly-ones guarantee.
 Even with such a system, Qdrant ensures data consistency.
 
-*Available since v0.10.0*
+*Available as of v0.10.0*
 
 If the collection was created with multiple vectors, each vector data should be provided using the vectors name:
 
@@ -555,7 +555,7 @@ Python client:
 
 ## Counting points
 
-*Available since v0.8.4*
+*Available as of v0.8.4*
 
 Sometimes it can be useful to know how many points fit the filter conditions without doing a real search.
 

--- a/qdrant/v0.11.x/search.md
+++ b/qdrant/v0.11.x/search.md
@@ -136,7 +136,7 @@ Example result of this API would be
 
 The `result` contains ordered by `score` list of found point ids.
 
-*Available since v0.10.0*
+*Available as of v0.10.0*
 
 If the collection was created with multiple vectors, the name of the vector to use for searching should be provided:
 
@@ -232,7 +232,7 @@ client.search(
 
 ## Batch search API
 
-*Available since v0.10.0*
+*Available as of v0.10.0*
 
 The batch search API enables to perform multiple search requests via a single request.
 
@@ -416,7 +416,7 @@ Example result of this API would be
 }
 ```
 
-*Available since v0.10.0*
+*Available as of v0.10.0*
 
 If the collection was created with multiple vectors, the name of the vector should be specified in the recommendation request:
 
@@ -445,7 +445,7 @@ Parameter `using` specifies which stored vectors to use for the recommendation.
 
 ## Batch recommendation API
 
-*Available since v0.10.0*
+*Available as of v0.10.0*
 
 Similar to the batch search API in terms of usage and advantages, it enables the batching of recommendation requests.
 
@@ -549,7 +549,7 @@ The result of this API contains one array per recommendation requests.
 
 ## Pagination
 
-*Available since v0.8.3*
+*Available as of v0.8.3*
 
 Search and recommendation APIs allow to skip first results of the search and return only the result starting from some specified offset:
 

--- a/qdrant/v0.11.x/snapshots.md
+++ b/qdrant/v0.11.x/snapshots.md
@@ -3,7 +3,7 @@ title: Snapshots
 weight: 51
 ---
 
-*Available since v0.8.4*
+*Available as of v0.8.4*
 
 Snapshots are performed on a per collection basis and consist in a `tar` archive file containing the necessary data to restore the collection at the time of the snapshot.
 
@@ -90,7 +90,7 @@ If you wish instead to overwrite an existing collection, use the `--force_snapsh
 
 ### Recover in cluster deployment
 
-*Available since v0.11.3*
+*Available as of v0.11.3*
 
 Recovering in cluster mode is more sophisticated, as Qdrant should maintain consistency across peers even during the recovery process.
 As the information about created collections is stored in the consensus, even a newly attached cluster node will automatically create collections.
@@ -119,7 +119,7 @@ If there are other active replicas of the recovered shards in the cluster, Qdran
 
 ## Snapshots for the whole storage
 
-*Available since v0.8.5*
+*Available as of v0.8.5*
 
 Sometimes it might be handy to create snapshot not just for a single collection, but for the whole storage, including collection aliases.
 Qdrant provides a dedicated API for that as well. It is similar to collection-level snapshots, but does not require `collecton_name`:

--- a/qdrant/v0.8.x/distributed_deployment.md
+++ b/qdrant/v0.8.x/distributed_deployment.md
@@ -3,7 +3,7 @@ title: Distributed deployment
 weight: 50
 ---
 
-Since version v0.8.0 Qdrant supports an experimental mode of distributed deployment.
+As of v0.8.0 Qdrant supports an experimental mode of distributed deployment.
 In this mode, multiple Qdrant services communicate with each other to distribute the data across the peers to extend the storage capabilities and increase stability.
 
 To enable distributed deployment - enable the cluster mode in the [configuration](../configuration) or using the ENV variable: `QDRANT__CLUSTER__ENABLED=true`.

--- a/qdrant/v0.8.x/points.md
+++ b/qdrant/v0.8.x/points.md
@@ -512,7 +512,7 @@ Python client:
 
 ## Counting points
 
-*Avalable since v0.8.4*
+*Available as of v0.8.4*
 
 Sometimes it can be useful to know how many points fit the filter conditions without doing a real search.
 

--- a/qdrant/v0.8.x/search.md
+++ b/qdrant/v0.8.x/search.md
@@ -268,7 +268,7 @@ Example result of this API would be
 
 ## Pagination
 
-*Avalable since v0.8.3*
+*Available as of v0.8.3*
 
 Search and recommendation APIs allow to skip first results of the search and return only the result starting from some specified offset:
 

--- a/qdrant/v0.8.x/snapshots.md
+++ b/qdrant/v0.8.x/snapshots.md
@@ -3,7 +3,7 @@ title: Snapshots
 weight: 51
 ---
 
-*Avalable since v0.8.4*
+*Available as of v0.8.4*
 
 Snapshots are performed on a per collection basis and consist in a `tar` archive file containing the necessary data to restore the collection at the time of the snapshot.
 
@@ -88,7 +88,7 @@ If you wish instead to overwrite an existing collection, use the `--force_snapsh
 
 ## Snapshots for the whole storage
 
-*Avalable since v0.8.5*
+*Available as of v0.8.5*
 
 Sometimes it might be handy to create snapshot not just for a single collection, but for the whole storage, including collection aliases.
 Qdrant provides a dedicated API for that as well. It is similar to collection-level snapshots, but does not require `collecton_name`:

--- a/qdrant/v0.9.x/distributed_deployment.md
+++ b/qdrant/v0.9.x/distributed_deployment.md
@@ -3,7 +3,7 @@ title: Distributed deployment
 weight: 50
 ---
 
-Since version v0.8.0 Qdrant supports an experimental mode of distributed deployment.
+As of v0.8.0 Qdrant supports an experimental mode of distributed deployment.
 In this mode, multiple Qdrant services communicate with each other to distribute the data across the peers to extend the storage capabilities and increase stability.
 
 To enable distributed deployment - enable the cluster mode in the [configuration](../configuration) or using the ENV variable: `QDRANT__CLUSTER__ENABLED=true`.
@@ -159,7 +159,7 @@ For example, if you have 3 nodes, 6 shards could be a good option.
 
 If you want to extend your cluster with new nodes or some nodes become slower than the others, it might be helpful to re-balance the shard distribution in the cluster.
 
-*Since version v0.9.0*, Qdrant allows moving shards between nodes in the cluster and removing nodes from the cluster.
+*As of v0.9.0:* Qdrant allows moving shards between nodes in the cluster and removing nodes from the cluster.
 
 This functionality unlocks the ability to dynamically scale the cluster size without downtime.
 

--- a/qdrant/v0.9.x/points.md
+++ b/qdrant/v0.9.x/points.md
@@ -512,7 +512,7 @@ Python client:
 
 ## Counting points
 
-*Avalable since v0.8.4*
+*Available as of v0.8.4*
 
 Sometimes it can be useful to know how many points fit the filter conditions without doing a real search.
 

--- a/qdrant/v0.9.x/search.md
+++ b/qdrant/v0.9.x/search.md
@@ -268,7 +268,7 @@ Example result of this API would be
 
 ## Pagination
 
-*Avalable since v0.8.3*
+*Available as of v0.8.3*
 
 Search and recommendation APIs allow to skip first results of the search and return only the result starting from some specified offset:
 

--- a/qdrant/v0.9.x/snapshots.md
+++ b/qdrant/v0.9.x/snapshots.md
@@ -3,7 +3,7 @@ title: Snapshots
 weight: 51
 ---
 
-*Avalable since v0.8.4*
+*Available as of v0.8.4*
 
 Snapshots are performed on a per collection basis and consist in a `tar` archive file containing the necessary data to restore the collection at the time of the snapshot.
 
@@ -88,7 +88,7 @@ If you wish instead to overwrite an existing collection, use the `--force_snapsh
 
 ## Snapshots for the whole storage
 
-*Avalable since v0.8.5*
+*Available as of v0.8.5*
 
 Sometimes it might be handy to create snapshot not just for a single collection, but for the whole storage, including collection aliases.
 Qdrant provides a dedicated API for that as well. It is similar to collection-level snapshots, but does not require `collecton_name`:

--- a/qdrant/v1.0.x/collections.md
+++ b/qdrant/v1.0.x/collections.md
@@ -62,7 +62,7 @@ See [schema definitions](https://qdrant.github.io/qdrant/redoc/index.html#operat
 
 ### Create collection from another collection
 
-*Available since v1.0.0*
+*Available as of v1.0.0*
 
 It is possible to initialize a collection from another existing collection.
 
@@ -102,7 +102,7 @@ client.recreate_collection(
 
 ### Collection with multiple vectors
 
-*Available since v0.10.0*
+*Available as of v0.10.0*
 
 It is possible to have multiple vectors per record.
 This feature allows for multiple vector storages per collection. 

--- a/qdrant/v1.0.x/distributed_deployment.md
+++ b/qdrant/v1.0.x/distributed_deployment.md
@@ -161,7 +161,7 @@ For example, if you have 3 nodes, 6 shards could be a good option.
 
 If you want to extend your cluster with new nodes or some nodes become slower than the others, it might be helpful to re-balance the shard distribution in the cluster.
 
-*Since version v0.9.0*, Qdrant allows moving shards between nodes in the cluster and removing nodes from the cluster.
+*As of v0.9.0:* Qdrant allows moving shards between nodes in the cluster and removing nodes from the cluster.
 
 This functionality unlocks the ability to dynamically scale the cluster size without downtime.
 
@@ -194,7 +194,7 @@ After that, Qdrant will exclude the node from the consensus, and the instance wi
 
 ## Replication
 
-*Since version v0.11.0*, Qdrant allows to replicate shards between nodes in the cluster.
+*As of v0.11.0:* Qdrant allows to replicate shards between nodes in the cluster.
 
 Shard replication increases the reliability of the cluster by keeping several copies of a shard spread among the cluster.
 This ensure the availability of the shards in case of node failures, except if all replicas are lost.

--- a/qdrant/v1.0.x/filtering.md
+++ b/qdrant/v1.0.x/filtering.md
@@ -330,7 +330,7 @@ You can apply it to [keyword](../payload/#keyword), [integer](../payload/#intege
 
 ### Full Text Match
 
-_Available since version 0.10.0_
+*Available as of v0.10.0*
 
 A special case of the `match` condition is the `text` match condition.
 It allows you to search for a specific substring, token or phrase within the text field.

--- a/qdrant/v1.0.x/indexing.md
+++ b/qdrant/v1.0.x/indexing.md
@@ -54,7 +54,7 @@ You should not create an index for Boolean fields and fields with only a few pos
 
 ### Full-text index
 
-*Available since Qdrant v0.10.0*
+*Available as of v0.10.0*
 
 Qdrant supports full-text search for string payload.
 Full-text index allows you to filter points by the presence of a word or a phrase in the payload field.

--- a/qdrant/v1.0.x/points.md
+++ b/qdrant/v1.0.x/points.md
@@ -250,7 +250,7 @@ In this case, it means that points with the same id will be overwritten when re-
 Idempotence property is useful if you use, for example, a message queue that doesn't provide an exactly-ones guarantee.
 Even with such a system, Qdrant ensures data consistency.
 
-*Available since v0.10.0*
+*Available as of v0.10.0*
 
 If the collection was created with multiple vectors, each vector data should be provided using the vectors name:
 
@@ -555,7 +555,7 @@ Python client:
 
 ## Counting points
 
-*Available since v0.8.4*
+*Available as of v0.8.4*
 
 Sometimes it can be useful to know how many points fit the filter conditions without doing a real search.
 

--- a/qdrant/v1.0.x/search.md
+++ b/qdrant/v1.0.x/search.md
@@ -136,7 +136,7 @@ Example result of this API would be
 
 The `result` contains ordered by `score` list of found point ids.
 
-*Available since v0.10.0*
+*Available as of v0.10.0*
 
 If the collection was created with multiple vectors, the name of the vector to use for searching should be provided:
 
@@ -232,7 +232,7 @@ client.search(
 
 ## Batch search API
 
-*Available since v0.10.0*
+*Available as of v0.10.0*
 
 The batch search API enables to perform multiple search requests via a single request.
 
@@ -416,7 +416,7 @@ Example result of this API would be
 }
 ```
 
-*Available since v0.10.0*
+*Available as of v0.10.0*
 
 If the collection was created with multiple vectors, the name of the vector should be specified in the recommendation request:
 
@@ -445,7 +445,7 @@ Parameter `using` specifies which stored vectors to use for the recommendation.
 
 ## Batch recommendation API
 
-*Available since v0.10.0*
+*Available as of v0.10.0*
 
 Similar to the batch search API in terms of usage and advantages, it enables the batching of recommendation requests.
 
@@ -549,7 +549,7 @@ The result of this API contains one array per recommendation requests.
 
 ## Pagination
 
-*Available since v0.8.3*
+*Available as of v0.8.3*
 
 Search and recommendation APIs allow to skip first results of the search and return only the result starting from some specified offset:
 

--- a/qdrant/v1.0.x/snapshots.md
+++ b/qdrant/v1.0.x/snapshots.md
@@ -3,7 +3,7 @@ title: Snapshots
 weight: 51
 ---
 
-*Available since v0.8.4*
+*Available as of v0.8.4*
 
 Snapshots are performed on a per collection basis and consist in a `tar` archive file containing the necessary data to restore the collection at the time of the snapshot.
 
@@ -41,7 +41,7 @@ This is a synchronous operation for which a `tar` archive file will be generated
 
 ### Delete snapshot
 
-*Available since v1.0.0*
+*Available as of v1.0.0*
 
 ```http
 DELETE /collections/{collection_name}/snapshots/{snapshot_name}
@@ -109,7 +109,7 @@ If you wish instead to overwrite an existing collection, use the `--force_snapsh
 
 ### Recover in cluster deployment
 
-*Available since v0.11.3*
+*Available as of v0.11.3*
 
 Recovering in cluster mode is more sophisticated, as Qdrant should maintain consistency across peers even during the recovery process.
 As the information about created collections is stored in the consensus, even a newly attached cluster node will automatically create collections.
@@ -138,7 +138,7 @@ If there are other active replicas of the recovered shards in the cluster, Qdran
 
 ## Snapshots for the whole storage
 
-*Available since v0.8.5*
+*Available as of v0.8.5*
 
 Sometimes it might be handy to create snapshot not just for a single collection, but for the whole storage, including collection aliases.
 Qdrant provides a dedicated API for that as well. It is similar to collection-level snapshots, but does not require `collecton_name`:
@@ -159,7 +159,7 @@ client.create_full_snapshot()
 
 ### Delete full storage snapshot
 
-*Available since v1.0.0*
+*Available as of v1.0.0*
 
 ```http
 DELETE /snapshots/{snapshot_name}

--- a/qdrant/v1.1.x/collections.md
+++ b/qdrant/v1.1.x/collections.md
@@ -63,7 +63,7 @@ See [schema definitions](https://qdrant.github.io/qdrant/redoc/index.html#operat
 
 ### Create collection from another collection
 
-*Available since v1.0.0*
+*Available as of v1.0.0*
 
 It is possible to initialize a collection from another existing collection.
 
@@ -103,7 +103,7 @@ client.recreate_collection(
 
 ### Collection with multiple vectors
 
-*Available since v0.10.0*
+*Available as of v0.10.0*
 
 It is possible to have multiple vectors per record.
 This feature allows for multiple vector storages per collection. 
@@ -144,7 +144,7 @@ client.recreate_collection(
 
 For rare use cases, it is possible to create a collection without any vector storage.
 
-*Available since v1.1.1*
+*Available as of v1.1.1*
 
 For each named vector you can optionally specify
 [`hnsw_config`](../indexing/#vector-index) or

--- a/qdrant/v1.1.x/configuration.md
+++ b/qdrant/v1.1.x/configuration.md
@@ -207,7 +207,7 @@ tls:
 
 ## Validation
 
-*Available since v1.1.1*
+*Available as of v1.1.1*
 
 The configuration is validated on startup. If a configuration is loaded but
 validation fails, a warning is logged. E.g.:

--- a/qdrant/v1.1.x/distributed_deployment.md
+++ b/qdrant/v1.1.x/distributed_deployment.md
@@ -3,7 +3,7 @@ title: Distributed deployment
 weight: 100
 ---
 
-Since version v0.8.0 Qdrant supports a distributed deployment mode.
+As of v0.8.0 Qdrant supports a distributed deployment mode.
 In this mode, multiple Qdrant services communicate with each other to distribute the data across the peers to extend the storage capabilities and increase stability.
 
 To enable distributed deployment - enable the cluster mode in the [configuration](../configuration) or using the ENV variable: `QDRANT__CLUSTER__ENABLED=true`.
@@ -160,7 +160,7 @@ For example, if you have 3 nodes, 6 shards could be a good option.
 
 If you want to extend your cluster with new nodes or some nodes become slower than the others, it might be helpful to re-balance the shard distribution in the cluster.
 
-*Since version v0.9.0*, Qdrant allows moving shards between nodes in the cluster and removing nodes from the cluster.
+*As of v0.9.0:* Qdrant allows moving shards between nodes in the cluster and removing nodes from the cluster.
 
 This functionality unlocks the ability to dynamically scale the cluster size without downtime.
 
@@ -193,7 +193,7 @@ After that, Qdrant will exclude the node from the consensus, and the instance wi
 
 ## Replication
 
-*Since version v0.11.0*, Qdrant allows to replicate shards between nodes in the cluster.
+*As of v0.11.0:* Qdrant allows to replicate shards between nodes in the cluster.
 
 Shard replication increases the reliability of the cluster by keeping several copies of a shard spread among the cluster.
 This ensure the availability of the shards in case of node failures, except if all replicas are lost.

--- a/qdrant/v1.1.x/filtering.md
+++ b/qdrant/v1.1.x/filtering.md
@@ -330,7 +330,7 @@ You can apply it to [keyword](../payload/#keyword), [integer](../payload/#intege
 
 ### Match Any
 
-_Available since version 1.1.0_
+*Available as of v1.1.0*
 
 In case you want to check if the stored value is one of multiple values, you can use the Match Any condition.
 Match Any works as a logical OR for the given values. It can also be described as a `IN` operator.
@@ -359,7 +359,7 @@ In this example, the condition will be satisfied if the stored value is either `
 
 ### Nested key
 
-_Available since version 1.1.0_
+*Available as of v1.1.0*
 
 Payloads being arbitrary JSON object, it is likely that you will need to filter on a nested field.
 
@@ -518,7 +518,7 @@ This query would only output the point with id 2 as only Japan has a city with t
 
 ### Full Text Match
 
-_Available since version 0.10.0_
+*Available as of v0.10.0*
 
 A special case of the `match` condition is the `text` match condition.
 It allows you to search for a specific substring, token or phrase within the text field.

--- a/qdrant/v1.1.x/indexing.md
+++ b/qdrant/v1.1.x/indexing.md
@@ -54,7 +54,7 @@ You should not create an index for Boolean fields and fields with only a few pos
 
 ### Full-text index
 
-*Available since Qdrant v0.10.0*
+*Available as of v0.10.0*
 
 Qdrant supports full-text search for string payload.
 Full-text index allows you to filter points by the presence of a word or a phrase in the payload field.
@@ -143,7 +143,7 @@ HNSW is chosen for several reasons.
 First, HNSW is well-compatible with the modification that allows Qdrant to use filters during a search.
 Second, it is one of the most accurate and fastest algorithms, according to [public benchmarks](https://github.com/erikbern/ann-benchmarks).
 
-*Available since v1.1.1*
+*Available as of v1.1.1*
 
 The HNSW parameters can also be configured on a collection and named vector
 level by setting [`hnsw_config`](../indexing/#vector-index) to fine-tune search

--- a/qdrant/v1.1.x/points.md
+++ b/qdrant/v1.1.x/points.md
@@ -250,7 +250,7 @@ In this case, it means that points with the same id will be overwritten when re-
 Idempotence property is useful if you use, for example, a message queue that doesn't provide an exactly-ones guarantee.
 Even with such a system, Qdrant ensures data consistency.
 
-*Available since v0.10.0*
+*Available as of v0.10.0*
 
 If the collection was created with multiple vectors, each vector data should be provided using the vectors name:
 
@@ -632,7 +632,7 @@ Python client:
 
 ## Counting points
 
-*Available since v0.8.4*
+*Available as of v0.8.4*
 
 Sometimes it can be useful to know how many points fit the filter conditions without doing a real search.
 

--- a/qdrant/v1.1.x/quantization.md
+++ b/qdrant/v1.1.x/quantization.md
@@ -23,7 +23,7 @@ The level of this tradeoff depends on the quantization method and its parameters
 
 ## Scalar Quantization
 
-*Available in Qdrant since v1.1.0*
+*Available as of v1.1.0*
 
 Scalar quantization, in the context of vector search engines, is a compression technique that compresses vectors by reducing the number of bits used to represent each vector component.
 
@@ -56,7 +56,7 @@ You can configure quantization for a collection by specifying the quantization p
 Quantization will be automatically applied to all vectors during the indexation process.
 Quantized vectors are stored alongside the original vectors in the collection, so you will still have access to the original vectors if you need them.
 
-*Available since v1.1.1*
+*Available as of v1.1.1*
 
 The `quantization_config` can also be set on a per vector basis by specifying it in a named vector.
 

--- a/qdrant/v1.1.x/search.md
+++ b/qdrant/v1.1.x/search.md
@@ -136,7 +136,7 @@ Example result of this API would be
 
 The `result` contains ordered by `score` list of found point ids.
 
-*Available since v0.10.0*
+*Available as of v0.10.0*
 
 If the collection was created with multiple vectors, the name of the vector to use for searching should be provided:
 
@@ -232,7 +232,7 @@ client.search(
 
 ## Batch search API
 
-*Available since v0.10.0*
+*Available as of v0.10.0*
 
 The batch search API enables to perform multiple search requests via a single request.
 
@@ -416,7 +416,7 @@ Example result of this API would be
 }
 ```
 
-*Available since v0.10.0*
+*Available as of v0.10.0*
 
 If the collection was created with multiple vectors, the name of the vector should be specified in the recommendation request:
 
@@ -445,7 +445,7 @@ Parameter `using` specifies which stored vectors to use for the recommendation.
 
 ## Batch recommendation API
 
-*Available since v0.10.0*
+*Available as of v0.10.0*
 
 Similar to the batch search API in terms of usage and advantages, it enables the batching of recommendation requests.
 
@@ -549,7 +549,7 @@ The result of this API contains one array per recommendation requests.
 
 ## Pagination
 
-*Available since v0.8.3*
+*Available as of v0.8.3*
 
 Search and recommendation APIs allow to skip first results of the search and return only the result starting from some specified offset:
 

--- a/qdrant/v1.1.x/snapshots.md
+++ b/qdrant/v1.1.x/snapshots.md
@@ -3,7 +3,7 @@ title: Snapshots
 weight: 110
 ---
 
-*Available since v0.8.4*
+*Available as of v0.8.4*
 
 Snapshots are performed on a per collection basis and consist in a `tar` archive file containing the necessary data to restore the collection at the time of the snapshot.
 
@@ -41,7 +41,7 @@ This is a synchronous operation for which a `tar` archive file will be generated
 
 ### Delete snapshot
 
-*Available since v1.0.0*
+*Available as of v1.0.0*
 
 ```http
 DELETE /collections/{collection_name}/snapshots/{snapshot_name}
@@ -109,7 +109,7 @@ If you wish instead to overwrite an existing collection, use the `--force_snapsh
 
 ### Recover in cluster deployment
 
-*Available since v0.11.3*
+*Available as of v0.11.3*
 
 Recovering in cluster mode is more sophisticated, as Qdrant should maintain consistency across peers even during the recovery process.
 As the information about created collections is stored in the consensus, even a newly attached cluster node will automatically create collections.
@@ -146,7 +146,7 @@ If there are other active replicas of the recovered shards in the cluster, Qdran
 
 ## Snapshots for the whole storage
 
-*Available since v0.8.5*
+*Available as of v0.8.5*
 
 Sometimes it might be handy to create snapshot not just for a single collection, but for the whole storage, including collection aliases.
 Qdrant provides a dedicated API for that as well. It is similar to collection-level snapshots, but does not require `collecton_name`:
@@ -167,7 +167,7 @@ client.create_full_snapshot()
 
 ### Delete full storage snapshot
 
-*Available since v1.0.0*
+*Available as of v1.0.0*
 
 ```http
 DELETE /snapshots/{snapshot_name}

--- a/qdrant/v1.2.x/administration.md
+++ b/qdrant/v1.2.x/administration.md
@@ -31,7 +31,7 @@ You can optionally provide the error message that should be used for error respo
 
 ## Recovery mode
 
-*Available since v1.2.0*
+*Available as of v1.2.0*
 
 Recovery mode can help in situations where Qdrant fails to start repeatedly.
 When starting in recovery mode, Qdrant only loads collection metadata to prevent

--- a/qdrant/v1.2.x/collections.md
+++ b/qdrant/v1.2.x/collections.md
@@ -63,7 +63,7 @@ See [schema definitions](https://qdrant.github.io/qdrant/redoc/index.html#operat
 
 ### Create collection from another collection
 
-*Available since v1.0.0*
+*Available as of v1.0.0*
 
 It is possible to initialize a collection from another existing collection.
 
@@ -103,7 +103,7 @@ client.recreate_collection(
 
 ### Collection with multiple vectors
 
-*Available since v0.10.0*
+*Available as of v0.10.0*
 
 It is possible to have multiple vectors per record.
 This feature allows for multiple vector storages per collection. 
@@ -144,7 +144,7 @@ client.recreate_collection(
 
 For rare use cases, it is possible to create a collection without any vector storage.
 
-*Available since v1.1.1*
+*Available as of v1.1.1*
 
 For each named vector you can optionally specify
 [`hnsw_config`](../indexing/#vector-index) or

--- a/qdrant/v1.2.x/configuration.md
+++ b/qdrant/v1.2.x/configuration.md
@@ -223,7 +223,7 @@ tls:
 
 ## Validation
 
-*Available since v1.1.1*
+*Available as of v1.1.1*
 
 The configuration is validated on startup. If a configuration is loaded but
 validation fails, a warning is logged. E.g.:

--- a/qdrant/v1.2.x/distributed_deployment.md
+++ b/qdrant/v1.2.x/distributed_deployment.md
@@ -3,7 +3,7 @@ title: Distributed deployment
 weight: 100
 ---
 
-Since version v0.8.0 Qdrant supports a distributed deployment mode.
+As of v0.8.0 Qdrant supports a distributed deployment mode.
 In this mode, multiple Qdrant services communicate with each other to distribute the data across the peers to extend the storage capabilities and increase stability.
 
 To enable distributed deployment - enable the cluster mode in the [configuration](../configuration) or using the ENV variable: `QDRANT__CLUSTER__ENABLED=true`.
@@ -160,7 +160,7 @@ For example, if you have 3 nodes, 6 shards could be a good option.
 
 If you want to extend your cluster with new nodes or some nodes become slower than the others, it might be helpful to re-balance the shard distribution in the cluster.
 
-*Since version v0.9.0*, Qdrant allows moving shards between nodes in the cluster and removing nodes from the cluster.
+*As of v0.9.0:* Qdrant allows moving shards between nodes in the cluster and removing nodes from the cluster.
 
 This functionality unlocks the ability to dynamically scale the cluster size without downtime.
 
@@ -193,7 +193,7 @@ After that, Qdrant will exclude the node from the consensus, and the instance wi
 
 ## Replication
 
-*Since version v0.11.0*, Qdrant allows to replicate shards between nodes in the cluster.
+*As of v0.11.0:* Qdrant allows to replicate shards between nodes in the cluster.
 
 Shard replication increases the reliability of the cluster by keeping several copies of a shard spread among the cluster.
 This ensure the availability of the shards in case of node failures, except if all replicas are lost.

--- a/qdrant/v1.2.x/filtering.md
+++ b/qdrant/v1.2.x/filtering.md
@@ -330,7 +330,7 @@ You can apply it to [keyword](../payload/#keyword), [integer](../payload/#intege
 
 ### Match Any
 
-_Available since version 1.1.0_
+*Available as of v1.1.0*
 
 In case you want to check if the stored value is one of multiple values, you can use the Match Any condition.
 Match Any works as a logical OR for the given values. It can also be described as a `IN` operator.
@@ -362,7 +362,7 @@ If the stored value is an array, it should have at least one value matching any 
 
 ### Match Except
 
-_Available since version 1.2.0_
+*Available as of v1.2.0*
 
 In case you want to check if the stored value is not one of multiple values, you can use the Match Except condition.
 Match Except works as a logical NOR for the given values.
@@ -394,7 +394,7 @@ If the stored value is an array, it should have at least one value not matching 
 
 ### Nested key
 
-_Available since version 1.1.0_
+*Available as of v1.1.0*
 
 Payloads being arbitrary JSON object, it is likely that you will need to filter on a nested field.
 
@@ -553,7 +553,7 @@ This query would only output the point with id 2 as only Japan has a city with t
 
 ### Nested object filter
 
-_Available since version 1.2.0_
+*Available as of v1.2.0*
 
 By default, the conditions are taking into account the entire payload of a point.
 
@@ -767,7 +767,7 @@ client.scroll(
 
 ### Full Text Match
 
-_Available since version 0.10.0_
+*Available as of v0.10.0*
 
 A special case of the `match` condition is the `text` match condition.
 It allows you to search for a specific substring, token or phrase within the text field.

--- a/qdrant/v1.2.x/indexing.md
+++ b/qdrant/v1.2.x/indexing.md
@@ -54,7 +54,7 @@ You should not create an index for Boolean fields and fields with only a few pos
 
 ### Full-text index
 
-*Available since Qdrant v0.10.0*
+*Available as of v0.10.0*
 
 Qdrant supports full-text search for string payload.
 Full-text index allows you to filter points by the presence of a word or a phrase in the payload field.
@@ -143,7 +143,7 @@ HNSW is chosen for several reasons.
 First, HNSW is well-compatible with the modification that allows Qdrant to use filters during a search.
 Second, it is one of the most accurate and fastest algorithms, according to [public benchmarks](https://github.com/erikbern/ann-benchmarks).
 
-*Available since v1.1.1*
+*Available as of v1.1.1*
 
 The HNSW parameters can also be configured on a collection and named vector
 level by setting [`hnsw_config`](../indexing/#vector-index) to fine-tune search

--- a/qdrant/v1.2.x/points.md
+++ b/qdrant/v1.2.x/points.md
@@ -250,7 +250,7 @@ In this case, it means that points with the same id will be overwritten when re-
 Idempotence property is useful if you use, for example, a message queue that doesn't provide an exactly-ones guarantee.
 Even with such a system, Qdrant ensures data consistency.
 
-*Available since v0.10.0*
+*Available as of v0.10.0*
 
 If the collection was created with multiple vectors, each vector data can be provided using the vector's name:
 
@@ -299,7 +299,7 @@ client.upsert(
 )
 ```
 
-*Available since v1.2.0*
+*Available as of v1.2.0*
 
 Named vectors are optional. When uploading points, some vectors may be omitted.
 For example, you can upload one point with only the `image` vector and a second
@@ -317,7 +317,7 @@ ways to do this.
 
 ### Update vectors
 
-*Available since v1.2.0*
+*Available as of v1.2.0*
 
 This method updates the specified vectors on the given points. Unspecified
 vectors are kept unchanged. All given points must exist.
@@ -370,7 +370,7 @@ points](#upload-points).
 
 ### Delete vectors
 
-*Available since v1.2.0*
+*Available as of v1.2.0*
 
 This method deletes just the specified vectors from the given points. Other
 vectors are kept unchanged. Points are never deleted.
@@ -724,7 +724,7 @@ Python client:
 
 ## Counting points
 
-*Available since v0.8.4*
+*Available as of v0.8.4*
 
 Sometimes it can be useful to know how many points fit the filter conditions without doing a real search.
 

--- a/qdrant/v1.2.x/quantization.md
+++ b/qdrant/v1.2.x/quantization.md
@@ -19,7 +19,7 @@ The level of this tradeoff depends on the quantization method and its parameters
 
 ## Scalar Quantization
 
-*Available in Qdrant since v1.1.0*
+*Available as of v1.1.0*
 
 Scalar quantization, in the context of vector search engines, is a compression technique that compresses vectors by reducing the number of bits used to represent each vector component.
 
@@ -42,7 +42,7 @@ Please refer to the [Quantization Tips](#quantization-tips) section for more inf
 
 ## Product Quantization
 
-*Available in Qdrant since v1.2.0*
+*Available as of v1.2.0*
 
 Product quantization is a method of compressing vectors to minimize their memory usage by dividing them into 
 chunks and quantizing each segment individually.
@@ -63,7 +63,7 @@ You can configure quantization for a collection by specifying the quantization p
 Quantization will be automatically applied to all vectors during the indexation process.
 Quantized vectors are stored alongside the original vectors in the collection, so you will still have access to the original vectors if you need them.
 
-*Available since v1.1.1*
+*Available as of v1.1.1*
 
 The `quantization_config` can also be set on a per vector basis by specifying it in a named vector.
 

--- a/qdrant/v1.2.x/search.md
+++ b/qdrant/v1.2.x/search.md
@@ -136,7 +136,7 @@ Example result of this API would be
 
 The `result` contains ordered by `score` list of found point ids.
 
-*Available since v0.10.0*
+*Available as of v0.10.0*
 
 If the collection was created with multiple vectors, the name of the vector to use for searching should be provided:
 
@@ -232,7 +232,7 @@ client.search(
 
 ## Batch search API
 
-*Available since v0.10.0*
+*Available as of v0.10.0*
 
 The batch search API enables to perform multiple search requests via a single request.
 
@@ -416,7 +416,7 @@ Example result of this API would be
 }
 ```
 
-*Available since v0.10.0*
+*Available as of v0.10.0*
 
 If the collection was created with multiple vectors, the name of the vector should be specified in the recommendation request:
 
@@ -445,7 +445,7 @@ Parameter `using` specifies which stored vectors to use for the recommendation.
 
 ## Batch recommendation API
 
-*Available since v0.10.0*
+*Available as of v0.10.0*
 
 Similar to the batch search API in terms of usage and advantages, it enables the batching of recommendation requests.
 
@@ -549,7 +549,7 @@ The result of this API contains one array per recommendation requests.
 
 ## Pagination
 
-*Available since v0.8.3*
+*Available as of v0.8.3*
 
 Search and recommendation APIs allow to skip first results of the search and return only the result starting from some specified offset:
 
@@ -595,7 +595,7 @@ Using an `offset` parameter, will require to internally retrieve `offset + limit
 
 ## Grouping API
 
-*Available since v1.2.0*
+*Available as of v1.2.0*
 
 It is possible to group results by a certain field. This is useful when you have multiple points for the same item, and you want to avoid redundancy of the same item in the results.
 

--- a/qdrant/v1.2.x/snapshots.md
+++ b/qdrant/v1.2.x/snapshots.md
@@ -3,7 +3,7 @@ title: Snapshots
 weight: 110
 ---
 
-*Available since v0.8.4*
+*Available as of v0.8.4*
 
 Snapshots are performed on a per collection basis and consist in a `tar` archive file containing the necessary data to restore the collection at the time of the snapshot.
 
@@ -41,7 +41,7 @@ This is a synchronous operation for which a `tar` archive file will be generated
 
 ### Delete snapshot
 
-*Available since v1.0.0*
+*Available as of v1.0.0*
 
 ```http
 DELETE /collections/{collection_name}/snapshots/{snapshot_name}
@@ -109,7 +109,7 @@ If you wish instead to overwrite an existing collection, use the `--force_snapsh
 
 ### Recover in cluster deployment
 
-*Available since v0.11.3*
+*Available as of v0.11.3*
 
 Recovering in cluster mode is more sophisticated, as Qdrant should maintain consistency across peers even during the recovery process.
 As the information about created collections is stored in the consensus, even a newly attached cluster node will automatically create collections.
@@ -146,7 +146,7 @@ If there are other active replicas of the recovered shards in the cluster, Qdran
 
 ## Snapshots for the whole storage
 
-*Available since v0.8.5*
+*Available as of v0.8.5*
 
 Sometimes it might be handy to create snapshot not just for a single collection, but for the whole storage, including collection aliases.
 Qdrant provides a dedicated API for that as well. It is similar to collection-level snapshots, but does not require `collecton_name`:
@@ -167,7 +167,7 @@ client.create_full_snapshot()
 
 ### Delete full storage snapshot
 
-*Available since v1.0.0*
+*Available as of v1.0.0*
 
 ```http
 DELETE /snapshots/{snapshot_name}

--- a/qdrant/v1.2.x/storage.md
+++ b/qdrant/v1.2.x/storage.md
@@ -41,7 +41,7 @@ There are two ways to configure the usage of mmap(also known as on-disk) storage
 
 - Set up `on_disk` option for the vectors in the collection create API:
 
-**Available since v1.2.0**
+*Available as of v1.2.0*
 
 
 ```http


### PR DESCRIPTION
This changes 120 occurrences of 'Available since v1.2.3' to 'Available as of v1.2.3' to make them all consistent.

@davidmyriel Feel free to add a commit on this branch if you think I missed something or if something should be improved.